### PR TITLE
A Construction and Overrides Update

### DIFF
--- a/MST_Extra/construction.json
+++ b/MST_Extra/construction.json
@@ -20,5 +20,38 @@
     ],
     "pre_flags": "DIGGABLE",
     "post_terrain": "t_hive_young"
+  },
+  {
+    "type": "construction",
+    "description": "Build Charcoal Purifier",
+    "category": "FURN",
+    "required_skills": [ [ "survival", 2 ] ],
+    "time": 25,
+    "qualities": [ [ { "id": "HAMMER", "level": 1 } ], [ { "id": "CUT", "level": 1 } ] ],
+    "components": [
+      [ [ "stick", 6 ], [ "2x4", 6 ] ],
+      [ [ "birchbark", 12 ], [ "withered", 24 ], [ "straw_pile", 24 ], [ "string_36", 2 ] ]
+    ],
+    "pre_note": "Can be deconstructed without tools.",
+    "pre_special": "check_empty",
+    "post_terrain": "f_char_purifier"
+  },
+  {
+    "type": "construction",
+    "description": "Build Leather Door Curtain",
+    "//": "Door frame not required",
+    "category": "CONSTRUCT",
+    "required_skills": [ [ "tailor", 1 ] ],
+    "time": 30,
+    "qualities": [ [ { "id": "HAMMER", "level": 2 } ] ],
+    "components": [
+      [ [ "nail", 4 ], [ "pointy_stick", 2 ], [ "spike", 2 ] ],
+      [ [ "leather_tarp", 1 ] ],
+      [ [ "stick", 1 ] ],
+      [ [ "withered", 12 ], [ "straw_pile", 12 ], [ "string_36", 1 ] ]
+    ],
+    "pre_note": "Can be deconstructed without tools.",
+    "pre_special": "check_empty",
+    "post_terrain": "t_door_curtain_leather_c"
   }
 ]

--- a/MST_Extra/furniture.json
+++ b/MST_Extra/furniture.json
@@ -1,0 +1,24 @@
+[
+  {
+    "type": "furniture",
+    "id": "f_char_purifier",
+    "name": "charcoal purifier",
+    "description": "A makeshift filter constructed to hold a supply of charcoal, for purifying water.",
+    "symbol": "=",
+    "looks_like": "char_purifier",
+    "bgcolor": "brown",
+    "move_cost_mod": -1,
+    "required_str": -1,
+    "flags": [ "SEALED", "CONTAINER", "NOITEM", "EASY_DECONSTRUCT" ],
+    "crafting_pseudo_item": "char_purifier",
+    "examine_action": "reload_furniture",
+    "deconstruct": { "items": [ { "item": "withered", "count": 24 }, { "item": "stick", "count": 6 } ] },
+    "bash": {
+      "str_min": 8,
+      "str_max": 30,
+      "sound": "crunch!",
+      "sound_fail": "whump!",
+      "items": [ { "item": "withered", "count": [ 1, 4 ] }, { "item": "stick", "count": [ 2, 4 ] } ]
+    }
+  }
+]

--- a/MST_Extra/item_overrides.json
+++ b/MST_Extra/item_overrides.json
@@ -19,5 +19,12 @@
     "type": "GENERIC",
     "name": "makeshift copper pot",
     "use_action": "HEAT_FOOD"
+  },
+  {
+    "id": "char_purifier",
+    "copy-from": "char_purifier",
+    "type": "GENERIC",
+    "name": "charcoal water purifier",
+    "sub": "water_purifier"
   }
 ]

--- a/MST_Extra/recipe_overrides.json
+++ b/MST_Extra/recipe_overrides.json
@@ -8,8 +8,8 @@
     "time": 1500,
     "reversible": true,
     "autolearn": true,
-    "components": [ [ [ "fur", 12 ], [ "tanned_pelt", 2 ], [ "cured_pelt", 2 ] ] ],
-    "flags": [ "BLIND_HARD" ]
+    "components": [ [ [ "fur", 12 ], [ "tanned_pelt", 2 ], [ "cured_pelt", 3 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "chestwrap_leather",
@@ -20,8 +20,8 @@
     "time": 1500,
     "reversible": true,
     "autolearn": true,
-    "components": [ [ [ "leather", 12 ], [ "tanned_hide", 2 ], [ "cured_hide", 2 ] ] ],
-    "flags": [ "BLIND_HARD" ]
+    "components": [ [ [ "leather", 12 ], [ "tanned_hide", 2 ], [ "cured_hide", 3 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "gloves_wraps_fur",
@@ -32,8 +32,8 @@
     "time": 1500,
     "reversible": true,
     "autolearn": true,
-    "components": [ [ [ "fur", 6 ], [ "tanned_pelt", 1 ], [ "cured_pelt", 1 ] ] ],
-    "flags": [ "BLIND_HARD" ]
+    "components": [ [ [ "fur", 6 ], [ "tanned_pelt", 1 ], [ "cured_pelt", 2 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "gloves_wraps_leather",
@@ -44,8 +44,8 @@
     "time": 1500,
     "reversible": true,
     "autolearn": true,
-    "components": [ [ [ "leather", 6 ], [ "tanned_hide", 1 ], [ "cured_hide", 1 ] ] ],
-    "flags": [ "BLIND_HARD" ]
+    "components": [ [ [ "leather", 6 ], [ "tanned_hide", 1 ], [ "cured_hide", 2 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "loincloth_fur",
@@ -68,8 +68,8 @@
     "time": 1500,
     "reversible": true,
     "autolearn": true,
-    "components": [ [ [ "fur", 9 ], [ "tanned_pelt", 1 ], [ "cured_pelt", 1 ] ] ],
-    "flags": [ "BLIND_HARD" ]
+    "components": [ [ [ "fur", 9 ], [ "tanned_pelt", 1 ], [ "cured_pelt", 2 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "footrags_leather",
@@ -80,8 +80,8 @@
     "time": 1500,
     "reversible": true,
     "autolearn": true,
-    "components": [ [ [ "leather", 9 ], [ "tanned_hide", 1 ], [ "cured_hide", 1 ] ] ],
-    "flags": [ "BLIND_HARD" ]
+    "components": [ [ [ "leather", 9 ], [ "tanned_hide", 1 ], [ "cured_hide", 2 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "type": "recipe",
@@ -94,5 +94,168 @@
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_W", "level": 1 } ],
     "components": [ [ [ "2x4", 2 ], [ "stick", 2 ] ], [ [ "nail", 5 ] ] ]
-  }
+  },
+  {
+    "result": "footrags",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_FEET",
+    "skill_used": "tailor",
+    "time": 1000,
+    "reversible": true,
+    "autolearn": true,
+    "components": [ [ [ "rag", 6 ] ] ],
+    "flags": [ "BLIND_EASY" ]
+  },
+  {
+    "result": "footrags_wool",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_FEET",
+    "skill_used": "tailor",
+    "time": 1000,
+    "reversible": true,
+    "autolearn": true,
+    "components": [ [ [ "felt_patch", 6 ] ] ],
+    "flags": [ "BLIND_EASY" ]
+  },
+  {
+    "result": "gloves_wraps",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_HANDS",
+    "skill_used": "tailor",
+    "time": 1000,
+    "reversible": true,
+    "autolearn": true,
+    "components": [ [ [ "rag", 4 ] ] ],
+    "flags": [ "BLIND_EASY" ]
+  },
+  {
+    "result": "gloves_wraps_wool",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_HANDS",
+    "skill_used": "tailor",
+    "time": 1000,
+    "reversible": true,
+    "autolearn": true,
+    "components": [ [ [ "felt_patch", 4 ] ] ],
+    "flags": [ "BLIND_EASY" ]
+  },
+  {
+    "result": "chestwrap",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_TORSO",
+    "skill_used": "tailor",
+    "time": 1000,
+    "reversible": true,
+    "autolearn": true,
+    "components": [ [ [ "rag", 9 ] ] ],
+    "flags": [ "BLIND_EASY" ]
+  },
+  {
+    "result": "chestwrap_wool",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_TORSO",
+    "skill_used": "tailor",
+    "time": 1000,
+    "reversible": true,
+    "autolearn": true,
+    "components": [ [ [ "felt_patch", 9 ] ] ],
+    "flags": [ "BLIND_EASY" ]
+  },
+  {
+    "type": "recipe",
+    "result": "water_clean",
+    "category": "CC_FOOD",
+    "id_suffix": "using_water_purifier",
+    "subcategory": "CSC_FOOD_DRINKS",
+    "skill_used": "cooking",
+    "time": 150,
+    "autolearn": true,
+    "tools": [ [ [ "water_purifier", 1 ] ] ],
+    "components": [ [ [ "water", 1 ] ] ],
+    "flags": [ "BLIND_EASY" ]
+  },
+  {
+    "type": "recipe",
+    "result": "screwdriver",
+    "id_suffix": "forged",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TOOLS",
+    "skill_used": "fabrication",
+    "difficulty": 6,
+    "time": 180000,
+    "autolearn": true,
+    "using": [ [ "forging_standard", 10 ], [ "steel_tiny", 1 ] ],
+    "qualities": [ { "id": "ANVIL", "level": 3 }, { "id": "HAMMER", "level": 3 }, { "id": "CHISEL", "level": 3 } ],
+    "tools": [ [ [ "tongs", -1 ] ], [ [ "swage", -1 ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
+    "components": [ [ [ "plastic_chunk", 1 ], [ "stick", 1 ], [ "2x4", 1 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "pliers",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TOOLS",
+    "skill_used": "fabrication",
+    "difficulty": 2,
+    "time": 300000,
+    "autolearn": true,
+    "qualities": [ { "id": "ANVIL", "level": 3 }, { "id": "HAMMER", "level": 3 }, { "id": "CHISEL", "level": 3 } ],
+    "tools": [ [ [ "tongs", -1 ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ], [ [ "forge", 100 ], [ "oxy_torch", 20 ] ] ],
+    "components": [ [ [ "steel_chunk", 1 ], [ "scrap", 3 ] ], [ [ "plastic_chunk", 1 ], [ "stick", 1 ], [ "2x4", 1 ], [ "hose", 1 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "hacksaw",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TOOLS",
+    "skill_used": "fabrication",
+    "difficulty": 4,
+    "time": 320000,
+    "autolearn": true,
+    "book_learn": [ [ "manual_mechanics", 3 ], [ "manual_fabrication", 3 ], [ "textbook_fabrication", 4 ] ],
+    "qualities": [ { "id": "ANVIL", "level": 3 }, { "id": "HAMMER", "level": 3 }, { "id": "CHISEL", "level": 3 } ],
+    "tools": [ [ [ "tongs", -1 ] ], [ [ "swage", -1 ] ], [ [ "forge", 200 ], [ "oxy_torch", 40 ] ] ],
+    "components": [ [ [ "steel_lump", 1 ], [ "steel_chunk", 4 ], [ "scrap", 12 ] ], [ [ "plastic_chunk", 1 ], [ "stick", 1 ], [ "2x4", 1 ], [ "bone", 1 ], [ "bone_human", 1 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "boltcutters",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TOOLS",
+    "skill_used": "fabrication",
+    "difficulty": 6,
+    "note": "not so much the engineering as hardening the edge",
+    "time": 380000,
+    "autolearn": true,
+    "book_learn": [ [ "manual_mechanics", 4 ], [ "manual_fabrication", 4 ], [ "textbook_fabrication", 4 ] ],
+    "qualities": [ { "id": "ANVIL", "level": 3 }, { "id": "HAMMER", "level": 3 }, { "id": "CHISEL", "level": 3 } ],
+    "tools": [ [ [ "tongs", -1 ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ], [ [ "forge", 300 ], [ "oxy_torch", 60 ] ] ],
+    "components": [ [ [ "steel_lump", 2 ], [ "steel_chunk", 8 ], [ "scrap", 24 ] ], [ [ "plastic_chunk", 2 ], [ "stick", 2 ], [ "2x4", 2 ], [ "hose", 2 ] ] ]
+  },
+{
+  "type" : "recipe",
+  "result": "pot_makeshift",
+  "category": "CC_OTHER",
+  "subcategory": "CSC_OTHER_TOOLS",
+  "skill_used": "survival",
+  "skills_required": [ "cooking", 1 ],
+  "difficulty": 1,
+  "time": 20000,
+  "autolearn": true,
+  "qualities":[
+    {"id":"HAMMER","level":1}
+  ],
+  "components":
+    [
+     [
+     [ "sheet_metal", 1 ],
+     [ "sheet_metal_small", 4 ]
+     ]
+    ]
+}
 ]

--- a/MST_Extra/recipes.json
+++ b/MST_Extra/recipes.json
@@ -417,7 +417,7 @@
     "reversible": true,
     "autolearn": true,
     "components": [ [ [ "leather", 12 ], [ "tanned_hide", 2 ], [ "cured_hide", 2 ] ] ],
-    "flags": [ "BLIND_HARD" ]
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "armwrap_fur",
@@ -429,7 +429,7 @@
     "reversible": true,
     "autolearn": true,
     "components": [ [ [ "fur", 12 ], [ "tanned_pelt", 2 ], [ "cured_pelt", 2 ] ] ],
-    "flags": [ "BLIND_HARD" ]
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "legwrap_leather",
@@ -441,7 +441,7 @@
     "reversible": true,
     "autolearn": true,
     "components": [ [ [ "leather", 12 ], [ "tanned_hide", 2 ], [ "cured_hide", 2 ] ] ],
-    "flags": [ "BLIND_HARD" ]
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "legwrap_fur",
@@ -453,7 +453,7 @@
     "reversible": true,
     "autolearn": true,
     "components": [ [ [ "fur", 12 ], [ "tanned_pelt", 2 ], [ "cured_pelt", 2 ] ] ],
-    "flags": [ "BLIND_HARD" ]
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "type": "recipe",

--- a/MST_Extra/terrain.json
+++ b/MST_Extra/terrain.json
@@ -1,146 +1,207 @@
 [
   {
-    "type" : "terrain",
-    "id" : "t_hive_young",
+    "type": "terrain",
+    "id": "t_hive_young",
     "name": "empty beehive",
+    "description": "A traditional beehive, dug in slightly and baited to attract bees.  It will take a while before any bees decide to make use of it",
     "symbol": "^",
     "color": "light_gray",
     "move_cost": 0,
     "transforms_into": "t_hive_growing",
-    "deconstruct": {
-      "ter_set": "t_dirt",
-      "items": [ { "item": "beehive_empty", "count": 1 } ]
-    },
-    "flags": ["FLAMMABLE_ASH", "TRANSPARENT", "PERMEABLE", "NOITEM", "EASY_DECONSTRUCT", "HARVESTED"],
+    "deconstruct": { "ter_set": "t_dirt", "items": [ { "item": "beehive_empty", "count": 1 } ] },
+    "flags": [ "FLAMMABLE_ASH", "TRANSPARENT", "PERMEABLE", "NOITEM", "EASY_DECONSTRUCT", "HARVESTED" ],
     "bash": {
-      "str_min": 12, "str_max": 40,
+      "str_min": 12,
+      "str_max": 40,
       "sound": "smash!",
       "sound_fail": "whump.",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "2x4", "count": [1, 4] },
-        { "item": "nail", "charges": [4, 8] },
-        { "item": "splinter", "count": [2, 6] }
+        { "item": "2x4", "count": [ 1, 4 ] },
+        { "item": "nail", "charges": [ 4, 8 ] },
+        { "item": "splinter", "count": [ 2, 6 ] }
       ]
     }
   },
   {
-    "type" : "terrain",
-    "id" : "t_hive_growing",
+    "type": "terrain",
+    "id": "t_hive_growing",
     "name": "growing beehive",
+    "description": "A traditional beehive, dug in slightly and buzzing with slight activity.  Some bees have started work on this hive, but it won't be ready just yet.",
     "symbol": "^",
     "color": "brown",
     "move_cost": 0,
     "transforms_into": "t_hive_ready",
-    "deconstruct": {
-      "ter_set": "t_dirt",
-      "items": [
-        { "item": "beehive_empty", "count": 1 },
-        { "item": "wax", "count": [1, 6] }
-      ]
-    },
-    "flags": ["FLAMMABLE_ASH", "TRANSPARENT", "PERMEABLE", "NOITEM", "EASY_DECONSTRUCT", "HARVESTED"],
+    "deconstruct": { "ter_set": "t_dirt", "items": [ { "item": "beehive_empty", "count": 1 }, { "item": "wax", "count": [ 1, 6 ] } ] },
+    "flags": [ "FLAMMABLE_ASH", "TRANSPARENT", "PERMEABLE", "NOITEM", "EASY_DECONSTRUCT", "HARVESTED" ],
     "bash": {
-      "str_min": 12, "str_max": 40,
+      "str_min": 12,
+      "str_max": 40,
       "sound": "smash!",
       "sound_fail": "whump.",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "wax", "count": [0, 1] },
-        { "item": "2x4", "count": [1, 4] },
-        { "item": "nail", "charges": [4, 8] },
-        { "item": "splinter", "count": [2, 6] }
+        { "item": "wax", "count": [ 0, 1 ] },
+        { "item": "2x4", "count": [ 1, 4 ] },
+        { "item": "nail", "charges": [ 4, 8 ] },
+        { "item": "splinter", "count": [ 2, 6 ] }
       ]
     }
   },
   {
-    "type" : "terrain",
-    "id" : "t_hive_ready",
+    "type": "terrain",
+    "id": "t_hive_ready",
     "name": "mature beehive",
+    "description": "A traditional beehive, dug in slightly and buzzing with activity.  The colony is doing well enough that you could harvest a good amount without the hive dying off.",
     "symbol": "^",
     "color": "yellow",
     "move_cost": 0,
     "transforms_into": "t_hive_recovering",
     "examine_action": "harvest_ter",
-    "harvest_by_season" : [ { "seasons": [ "spring", "summer", "autumn", "winter" ], "entries": [ { "drop": "honeycomb", "base_num": [ 2, 3 ], "scaled_num": [ 0.2, 0.5 ] } ] } ],
+    "harvest_by_season": [
+      {
+        "seasons": [ "spring", "summer", "autumn", "winter" ],
+        "entries": [ { "drop": "honeycomb", "base_num": [ 2, 3 ], "scaled_num": [ 0.2, 0.5 ] } ]
+      }
+    ],
     "deconstruct": {
       "ter_set": "t_dirt",
-      "items": [
-        { "item": "beehive_empty", "count": 1 },
-        { "item": "honeycomb", "count": [1, 6] }
-      ]
+      "items": [ { "item": "beehive_empty", "count": 1 }, { "item": "honeycomb", "count": [ 1, 6 ] } ]
     },
-    "flags": ["FLAMMABLE_ASH", "TRANSPARENT", "PERMEABLE", "NOITEM", "EASY_DECONSTRUCT"],
+    "flags": [ "FLAMMABLE_ASH", "TRANSPARENT", "PERMEABLE", "NOITEM", "EASY_DECONSTRUCT" ],
     "bash": {
-      "str_min": 12, "str_max": 40,
+      "str_min": 12,
+      "str_max": 40,
       "sound": "smash!",
       "sound_fail": "whump.",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "wax", "count": [2, 12] },
-        { "item": "honeycomb", "count": [0, 3] },
-        { "item": "2x4", "count": [1, 4] },
-        { "item": "nail", "charges": [4, 8] },
-        { "item": "splinter", "count": [2, 6] }
+        { "item": "wax", "count": [ 2, 12 ] },
+        { "item": "honeycomb", "count": [ 0, 3 ] },
+        { "item": "2x4", "count": [ 1, 4 ] },
+        { "item": "nail", "charges": [ 4, 8 ] },
+        { "item": "splinter", "count": [ 2, 6 ] }
       ]
     }
   },
   {
-    "type" : "terrain",
-    "id" : "t_hive_recovering",
+    "type": "terrain",
+    "id": "t_hive_recovering",
     "name": "recovering beehive",
+    "description": "A traditional beehive, dug in slightly and buzzing with activity.  The colony is still recovering from last harvest.",
     "symbol": "^",
     "color": "brown",
     "move_cost": 0,
     "transforms_into": "t_hive_regrowing",
     "deconstruct": {
       "ter_set": "t_dirt",
-      "items": [
-        { "item": "beehive_empty", "count": 1 },
-        { "item": "honeycomb", "count": [0, 1] }
-      ]
+      "items": [ { "item": "beehive_empty", "count": 1 }, { "item": "honeycomb", "count": [ 0, 1 ] } ]
     },
-    "flags": ["FLAMMABLE_ASH", "TRANSPARENT", "PERMEABLE", "NOITEM", "EASY_DECONSTRUCT", "HARVESTED"],
+    "flags": [ "FLAMMABLE_ASH", "TRANSPARENT", "PERMEABLE", "NOITEM", "EASY_DECONSTRUCT", "HARVESTED" ],
     "bash": {
-      "str_min": 12, "str_max": 40,
+      "str_min": 12,
+      "str_max": 40,
       "sound": "smash!",
       "sound_fail": "whump.",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "wax", "count": [1, 6] },
-        { "item": "2x4", "count": [1, 4] },
-        { "item": "nail", "charges": [4, 8] },
-        { "item": "splinter", "count": [2, 6] }
+        { "item": "wax", "count": [ 1, 6 ] },
+        { "item": "2x4", "count": [ 1, 4 ] },
+        { "item": "nail", "charges": [ 4, 8 ] },
+        { "item": "splinter", "count": [ 2, 6 ] }
       ]
     }
   },
   {
-    "type" : "terrain",
-    "id" : "t_hive_regrowing",
+    "type": "terrain",
+    "id": "t_hive_regrowing",
     "name": "regrowing beehive",
+    "description": "A traditional beehive, dug in slightly and buzzing with activity.  The colony is rebuilding honeycombs and producing more honey, but it still isn't ready.",
     "symbol": "^",
     "color": "brown",
     "move_cost": 0,
     "transforms_into": "t_hive_ready",
     "deconstruct": {
       "ter_set": "t_dirt",
-      "items": [
-        { "item": "beehive_empty", "count": 1 },
-        { "item": "honeycomb", "count": [1, 3] }
-      ]
+      "items": [ { "item": "beehive_empty", "count": 1 }, { "item": "honeycomb", "count": [ 1, 3 ] } ]
     },
-    "flags": ["FLAMMABLE_ASH", "TRANSPARENT", "PERMEABLE", "NOITEM", "EASY_DECONSTRUCT", "HARVESTED"],
+    "flags": [ "FLAMMABLE_ASH", "TRANSPARENT", "PERMEABLE", "NOITEM", "EASY_DECONSTRUCT", "HARVESTED" ],
     "bash": {
-      "str_min": 12, "str_max": 40,
+      "str_min": 12,
+      "str_max": 40,
       "sound": "smash!",
       "sound_fail": "whump.",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "wax", "count": [2, 6] },
-        { "item": "honeycomb", "count": [0, 1] },
-        { "item": "2x4", "count": [1, 4] },
-        { "item": "nail", "charges": [4, 8] },
-        { "item": "splinter", "count": [2, 6] }
+        { "item": "wax", "count": [ 2, 6 ] },
+        { "item": "honeycomb", "count": [ 0, 1 ] },
+        { "item": "2x4", "count": [ 1, 4 ] },
+        { "item": "nail", "charges": [ 4, 8 ] },
+        { "item": "splinter", "count": [ 2, 6 ] }
+      ]
+    }
+  },
+  {
+    "type": "terrain",
+    "id": "t_door_curtain_leather_c",
+    "name": "closed leather door curtain",
+    "description": "Hides from an animal hung up as a door.  Could be easily taken down for supplies or placed somewhere else.",
+    "symbol": "+",
+    "looks_like": "t_door_curtain_c",
+    "color": "dark_gray",
+    "move_cost": 0,
+    "roof": "t_flat_roof",
+    "flags": [ "FLAMMABLE_HARD", "DOOR", "NOITEM", "CONNECT_TO_WALL", "EASY_DECONSTRUCT" ],
+    "open": "t_door_curtain_o",
+    "deconstruct": {
+      "ter_set": "t_dirt",
+      "items": [ { "item": "stick", "count": 1 }, { "item": "leather_tarp", "count": 1 }, { "item": "withered", "count": 12 } ]
+    },
+    "bash": {
+      "str_min": 1,
+      "str_max": 8,
+      "sound": "rrrrip!",
+      "sound_fail": "slap!",
+      "sound_vol": 8,
+      "sound_fail_vol": 2,
+      "ter_set": "t_dirt",
+      "items": [
+        { "item": "sheet", "count": [ 0, 1 ] },
+        { "item": "leather", "count": [ 4, 10 ] },
+        { "item": "stick", "count": 1 },
+        { "item": "withered", "count": [ 2, 12 ] }
+      ]
+    }
+  },
+  {
+    "type": "terrain",
+    "id": "t_door_curtain_leather_o",
+    "name": "open leather door curtain",
+    "description": "Hides from an animal hung up as a door.  Could be easily taken down for supplies or placed somewhere else.  These curtains are open, bundled and tied next to the doorway.",
+    "symbol": "'",
+    "looks_like": "t_door_curtain_o",
+    "color": "dark_gray",
+    "move_cost": 2,
+    "roof": "t_flat_roof",
+    "flags": [ "FLAMMABLE_HARD", "TRANSPARENT", "FLAT", "CONNECT_TO_WALL", "ROAD", "EASY_DECONSTRUCT" ],
+    "deconstruct": {
+      "ter_set": "t_dirt",
+      "items": [ { "item": "stick", "count": 1 }, { "item": "leather_tarp", "count": 1 }, { "item": "withered", "count": 12 } ]
+    },
+    "close": "t_door_curtain_c",
+    "bash": {
+      "str_min": 1,
+      "str_max": 8,
+      "sound": "rrrrip!",
+      "sound_fail": "slap!",
+      "sound_vol": 8,
+      "sound_fail_vol": 2,
+      "ter_set": "t_dirt",
+      "items": [
+        { "item": "sheet", "count": [ 0, 1 ] },
+        { "item": "leather", "count": [ 4, 10 ] },
+        { "item": "stick", "count": 1 },
+        { "item": "withered", "count": [ 2, 12 ] }
       ]
     }
   }


### PR DESCRIPTION
* Changed makeshift wrap clothing to allow crafting in darkness as seemingly intended, via BLIND_EASY instead of BLIND_HARD.
* Made it so that charcoal water purifiers correctly substitute for electric water purifiers, and added BLIND_EASY to the recipe after experience showing that it doesn't actually enable operation by feel as
expected.
* Added a constructed version of the charcoal purifier.
* Added a leather version of door curtains, making use of leather tarps.
* Added an idea I could've sworn was gonna be added to vanilla a long time ago, overhauling many forged tool recipes to allow alternatives for the handle materials.
* Added a long-overdue override making it so that makeshift pots allow small metal sheets.