### PR TITLE
Terrain/furniture additons

### DIFF
--- a/MST_Extra/construction.json
+++ b/MST_Extra/construction.json
@@ -106,11 +106,24 @@
     "description": "Build Wooden Windbreak",
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 0 ] ],
-    "time": 30,
+    "time": 50,
     "qualities": [ [ { "id": "HAMMER", "level": 1 } ] ],
     "components": [ [ [ "stick_long", 8 ] ], [ [ "stick_long", 4 ] ] ],
     "pre_note": "Can be deconstructed without tools.",
     "pre_special": "check_empty",
     "post_terrain": "f_barricade_windbreak"
+  },
+  {
+    "type": "construction",
+    "skill": "survival",
+    "description": "Build Leather Tarp Lean-To",
+    "category": "CONSTRUCT",
+    "difficulty": 1,
+    "time": 50,
+    "qualities": [ { "id": "HAMMER", "level": 1 } ],
+    "components": [ [ [ "pointy_stick", 4 ] ], [ [ "cordage_short", 4, "LIST" ] ], [ [ "leather_tarp", 1 ] ] ],
+    "pre_note": "Can be deconstructed without tools.",
+    "pre_flags": [ "DIGGABLE", "FLAT" ],
+    "post_terrain": "t_tarptent_leather"
   }
 ]

--- a/MST_Extra/construction.json
+++ b/MST_Extra/construction.json
@@ -65,5 +65,52 @@
     "pre_note": "Can be deconstructed without tools.",
     "pre_special": "check_empty",
     "post_terrain": "t_door_curtain_leather_c"
+  },
+  {
+    "type": "construction",
+    "description": "Build Makeshift Still",
+    "category": "CONSTRUCT",
+    "required_skills": [ [ "fabrication", 2 ], [ "survival", 2 ] ],
+    "time": 30,
+    "qualities": [ [ { "id": "DIG", "level": 1 } ] ],
+    "components": [ [ [ "bottle_glass", 2 ] ] ],
+    "pre_note": "Can be deconstructed without tools.",
+    "pre_terrain": "t_dirtmound",
+    "post_terrain": "f_still_mounds"
+  },
+  {
+    "type": "construction",
+    "description": "Build Makeshift Still",
+    "category": "CONSTRUCT",
+    "required_skills": [ [ "fabrication", 2 ], [ "survival", 2 ] ],
+    "time": 30,
+    "qualities": [ [ { "id": "DIG", "level": 1 } ] ],
+    "components": [ [ [ "bottle_glass", 2 ] ] ],
+    "pre_terrain": "t_sandmound",
+    "post_terrain": "f_still_mounds"
+  },
+  {
+    "type": "construction",
+    "description": "Build Pulley Lifter",
+    "category": "CONSTRUCT",
+    "required_skills": [ [ "fabrication", 5 ], [ "mechanics", 2 ] ],
+    "time": 60,
+    "qualities": [ [ { "id": "HAMMER", "level": 2 } ] ],
+    "components": [ [ [ "rope_makeshift_30", 1 ], [ "rope_30", 1 ], [ "vine_30", 1 ] ], [ [ "stick", 8 ], [ "2x4", 8 ] ], [ [ "nail", 10 ] ] ],
+    "pre_note": "Can be deconstructed without tools.",
+    "pre_flags": [ "INDOORS", "SUPPORTS_ROOF" ],
+    "post_terrain": "t_palisade_pulley"
+  },
+  {
+    "type": "construction",
+    "description": "Build Wooden Windbreak",
+    "category": "CONSTRUCT",
+    "required_skills": [ [ "fabrication", 0 ] ],
+    "time": 30,
+    "qualities": [ [ { "id": "HAMMER", "level": 1 } ] ],
+    "components": [ [ [ "stick_long", 8 ] ], [ [ "stick_long", 4 ] ] ],
+    "pre_note": "Can be deconstructed without tools.",
+    "pre_special": "check_empty",
+    "post_terrain": "f_barricade_windbreak"
   }
 ]

--- a/MST_Extra/furniture.json
+++ b/MST_Extra/furniture.json
@@ -20,5 +20,82 @@
       "sound_fail": "whump!",
       "items": [ { "item": "withered", "count": [ 1, 4 ] }, { "item": "stick", "count": [ 2, 4 ] } ]
     }
+  },
+  {
+    "type": "furniture",
+    "id": "f_still_mounds",
+    "name": "makeshift still",
+    "symbol": "#",
+    "description": "A pair of glass bottles insulated with dirt or sand.  With careful alignment, it serves as a crude alembic by boiling away liquid in the first container, condensing into the second.",
+    "color": "brown",
+    "move_cost_mod": -1,
+    "required_str": -1,
+    "crafting_pseudo_item": "mound_distillation",
+    "flags": [ "PLACE_ITEM", "TRANSPARENT", "EASY_DECONSTRUCT" ],
+    "deconstruct": {
+      "items": [
+        { "item": "bottle_glass", "count": 2 }
+      ]
+    },
+    "max_volume": 3000,
+    "bash": {
+      "str_min": 12,
+      "str_max": 40,
+      "sound": "crunch!",
+      "sound_fail": "whump.",
+      "items": [
+        { "item": "glass_shard", "count": [ 1, 2 ] }
+      ]
+    }
+  },
+  {
+    "type": "furniture",
+    "id": "f_pulley_lifter",
+    "name": "rope and pulley lifter",
+    "symbol": "|",
+    "description": "A system of ropes and pulleys hanging from the ceiling, rigged up to serve as a block and tackle for lifting vehicle components, or even light enough vehicles.  It isn't very powerful, but it'll do in a pinch.",
+    "color": "brown",
+    "move_cost_mod": 0,
+    "required_str": -1,
+    "crafting_pseudo_item": "pulley_lifting",
+    "flags": [ "PLACE_ITEM", "TRANSPARENT", "EASY_DECONSTRUCT", "FLAMMABLE_ASH", "NOCOLLIDE" ],
+    "deconstruct": {
+      "items": [
+        { "item": "rope_makeshift_30", "count": 1 },
+        { "item": "2x4", "count": 8 }
+      ]
+    },
+    "bash": {
+      "str_min": 8,
+      "str_max": 40,
+      "sound": "crunch!",
+      "sound_fail": "whump.",
+      "items": [
+        { "item": "rope_makeshift_6", "count": [ 3, 4 ] },
+        { "item": "2x4", "count": [ 1, 4 ] },
+        { "item": "splinter", "count": [ 2, 4 ] }
+
+      ]
+    }
+  },
+  {
+    "type": "furniture",
+    "id": "f_barricade_windbreak",
+    "name": "wooden windbreak",
+    "symbol": "#",
+    "bgcolor": "brown",
+    "description": "A waist-high barricade made of stout saplings, held in place by poles hammered into the ground.  Primarily used to keep the wind out, but also works to fence in  a campsite.",
+    "move_cost_mod": -1,
+    "required_str": -1,
+    "flags": [ "CLIMB_SIMPLE", "TRANSPARENT", "FLAMMABLE_ASH", "ORGANIC", "MOUNTABLE", "THIN_OBSTACLE", "CLIMBABLE", "PERMEABLE", "EASY_DECONSTRUCT", "BLOCK_WIND" ],
+    "examine_action": "chainfence",
+    "deconstruct": { "items": [ { "item": "stick_long", "count": 8 }, { "item": "pointy_stick", "charges": 4 } ] },
+    "bash": {
+      "str_min": 3,
+      "str_max": 40,
+      "sound": "smash!",
+      "sound_fail": "whump.",
+      "items": [ { "item": "stick", "count": [ 2, 6 ] }, { "item": "splinter", "count": [ 2, 6 ] } ]
+    }
   }
 ]

--- a/MST_Extra/furniture.json
+++ b/MST_Extra/furniture.json
@@ -26,6 +26,7 @@
     "id": "f_still_mounds",
     "name": "makeshift still",
     "symbol": "#",
+    "looks_like": "bottle_glass",
     "description": "A pair of glass bottles insulated with dirt or sand.  With careful alignment, it serves as a crude alembic by boiling away liquid in the first container, condensing into the second.",
     "color": "brown",
     "move_cost_mod": -1,
@@ -53,6 +54,7 @@
     "id": "f_pulley_lifter",
     "name": "rope and pulley lifter",
     "symbol": "|",
+    "looks_like": "vp_crane_tiny",
     "description": "A system of ropes and pulleys hanging from the ceiling, rigged up to serve as a block and tackle for lifting vehicle components, or even light enough vehicles.  It isn't very powerful, but it'll do in a pinch.",
     "color": "brown",
     "move_cost_mod": 0,
@@ -84,6 +86,7 @@
     "name": "wooden windbreak",
     "symbol": "#",
     "bgcolor": "brown",
+    "looks_like": "f_barricade_road",
     "description": "A waist-high barricade made of stout saplings, held in place by poles hammered into the ground.  Primarily used to keep the wind out, but also works to fence in  a campsite.",
     "move_cost_mod": -1,
     "required_str": -1,
@@ -97,5 +100,31 @@
       "sound_fail": "whump.",
       "items": [ { "item": "stick", "count": [ 2, 6 ] }, { "item": "splinter", "count": [ 2, 6 ] } ]
     }
+  },
+  {
+    "id": "t_tarptent_leather",
+    "type": "terrain",
+    "name": "leather tarp lean-to",
+    "symbol": ";",
+    "looks_like": "t_tarptent",
+    "color": [ "brown" ],
+    "move_cost": 2,
+    "bash": {
+      "str_min": 6,
+      "str_max": 12,
+      "ter_set": "t_dirt",
+      "sound": "crash!",
+      "sound_fail": "whack!",
+      "items": [
+        { "item": "stick", "count": [ 1, 2 ] },
+        { "item": "splinter", "count": [ 1, 4 ] },
+        { "item": "leather", "count": [ 4, 8 ] }
+      ]
+    },
+    "deconstruct": {
+      "ter_set": "t_dirt",
+      "items": [ { "item": "pointy_stick", "count": 4 }, { "item": "withered", "count": 8 }, { "item": "leather_tarp", "count": 1 } ]
+    },
+    "flags": [ "TRANSPARENT", "FLAMMABLE", "THIN_OBSTACLE", "INDOORS", "MOUNTABLE", "EASY_DECONSTRUCT" ]
   }
 ]

--- a/MST_Extra/items.json
+++ b/MST_Extra/items.json
@@ -401,5 +401,21 @@
     "charges": 3,
     "stack_size": 9,
     "use_action": { "type": "heal", "bandages_power": 3, "bleed": 0.75, "bite": 0.75, "move_cost": 300 }
+  },
+  {
+    "id": "mound_distillation",
+    "type": "TOOL",
+    "copy-from": "fake_item",
+    "name": "makeshift distillation",
+    "description": "This exists only to allow makeshift stills to provide distilling quality.",
+    "qualities": [ [ "DISTILL", 1 ] ]
+  },
+  {
+    "id": "pulley lifting",
+    "type": "TOOL",
+    "copy-from": "fake_item",
+    "name": "pulley lifting",
+    "description": "This exists only to allow rope and pulley lifters to provide some engineering qualities.",
+    "qualities": [ [ "LIFT", 1 ], [ "JACK", 1 ] ]
   }
 ]

--- a/MST_Extra/recipes.json
+++ b/MST_Extra/recipes.json
@@ -628,5 +628,21 @@
         [ "tinder", 25 ]
       ]
     ]
+  },
+  {
+    "type": "recipe",
+    "result": "water_clean",
+    "id_suffix": "distillation",
+    "category": "CC_FOOD",
+    "subcategory": "CSC_FOOD_DRINKS",
+    "skill_used": "cooking",
+    "difficulty": 1,
+    "skills_required": [ "survival", 1 ],
+    "time": 10000,
+    "autolearn": true,
+    "batch_time_factors": [ 80, 4 ],
+    "qualities": [ { "id": "DISTILL", "level": 1 } ],
+    "tools": [ [ [ "water_boiling_heat", 3, "LIST" ] ] ],
+    "components": [ [ [ "salt_water", 1 ] ] ]
   }
 ]


### PR DESCRIPTION
Self-PR'd it partly to get some feedback, but also because was bouncing back and forth between laptop and desktop.

* Added an idea I saw an interesting video on, the use of a pair of bottles as a makeshift still, insulated by sand (possibly soil). For this, I've set it to be built on a dirt mound or sand mound. I would've made it let you built anywhere using soil or sand, but the logic for soil production and usage isn't quite fixed in stone just yet, so doing it this way lets me avoid having to change the math later.
* Also added a recipe for making clean water from salt water. Unlikely to be highly useful given access to fresh water isn't as major a concern anymore, but potentially handy. Only reason you don't get any salt as a by-product is because by-products only let you specify full stacks of items with charges. Given the choice between forcing the player to boil it in batches vs. simply not getting a paltry 10 salt each...
* Added a constructable pulley lifter, constructed indoors to basically hang a block and tackle for lightweight lifting duty.
* Added wooden windbreaks, again based off ideas I've seen elsewhere. Works as a crude barricade, or (as the name suggests) to block wind. We don't really have a way to screen against wind only when the player's actually sitting down in a shelter, but the idea should be reasonably clear.
* Added leather tarp lean-tos, as a compliment to the basic tarp lean-to in normal More Survival Tools. Likely a bit more accessible innawoods as well.