### PR TITLE
Item additions

### DIFF
--- a/MST_Extra/items.json
+++ b/MST_Extra/items.json
@@ -500,9 +500,9 @@
   {
     "type": "TOOL_ARMOR",
     "id": "side_drum_makeshift",
-    "name": "makeshift side drum",
+    "name": "side drum",
     "category": "tools",
-    "weight": 1000,
+    "weight": 1800,
     "color": "brown",
     "covers": [ "TORSO" ],
     "max_charges": 1,
@@ -519,7 +519,11 @@
         "You strike a steady beat on the side drum.",
         "Your drum beats with the cadence of an army on the march."
       ],
-      "npc_descriptions": [ "play a simple rhythm on the drum.", "strike a steady beat on the side drum.", "the drumming of an army on the march." ]
+      "npc_descriptions": [
+        "play a simple rhythm on the drum.",
+        "strike a steady beat on the side drum.",
+        "sound the cadence of an army on the march."
+      ]
     },
     "symbol": "-",
     "description": "A handmade side drum with a shoulder strap, allowing you to wear it while playing.",
@@ -531,5 +535,50 @@
     "flags": [ "WAIST" ],
     "coverage": 10,
     "material_thickness": 2
+  },
+  {
+    "id": "pot_canning_clay",
+    "type": "GENERIC",
+    "category": "tools",
+    "name": "clay canning pot",
+    "sub": "pot_canning",
+    "looks_like": "pot_canning",
+    "description": "A very large 25 liter earthenware pot, primarily meant for canning food via the water bath method, though it can cook normal foods just as well.  Canning foods with it will require a lot of water.  If you're only canning a couple of jars at a time, you'd fill it up with rocks or something to displace the water above the lids.",
+    "weight": "3250 g",
+    "volume": "25 L",
+    "price": 10000,
+    "to_hit": -2,
+    "bashing": 9,
+    "material": "clay",
+    "symbol": ")",
+    "color": "brown",
+    "container_data": { "contains": "25 L", "watertight": true },
+    "qualities": [ [ "COOK", 3 ], [ "BOIL", 2 ], [ "CONTAIN", 1 ], [ "CHEM", 1 ] ],
+    "use_action": "HEAT_FOOD"
+  },
+  {
+    "id": "posca",
+    "type": "COMESTIBLE",
+    "comestible_type": "DRINK",
+    "name": "posca",
+    "name_plural": "posca",
+    "description": "A traditional Roman drink made of cheap, often sour wine watered down, and usually made more palatable with herbs and honey.",
+    "weight": 230,
+    "volume": 1,
+    "price": 250,
+    "phase": "liquid",
+    "container": "waterskin",
+    "material": [ "alcohol", "water" ],
+    "symbol": "~",
+    "color": "light_red",
+    "vitamins": [ [ "vitA", 10 ], [ "vitC", 6 ], [ "calcium", 2 ], [ "iron", 1 ] ],
+    "calories": 60,
+    "quench": 40,
+    "stim": -1,
+    "fun": 6,
+    "addiction_type": "alcohol",
+    "addiction_potential": 1,
+    "use_action": "ALCOHOL_WEAK",
+    "flags": [ "EATEN_COLD" ]
   }
 ]

--- a/MST_Extra/items.json
+++ b/MST_Extra/items.json
@@ -496,5 +496,40 @@
       "not_ready_msg": "The scrap of tanning fur isn't done yet.",
       "//": "Should be 9.6 hours, but I suspect the timing hasn't been updated yet."
     }
+  },
+  {
+    "type": "TOOL_ARMOR",
+    "id": "side_drum_makeshift",
+    "name": "makeshift side drum",
+    "category": "tools",
+    "weight": 1000,
+    "color": "brown",
+    "covers": [ "TORSO" ],
+    "max_charges": 1,
+    "initial_charges": 1,
+    "use_action": {
+      "type": "musical_instrument",
+      "speed_penalty": 15,
+      "volume": 20,
+      "fun": 2,
+      "fun_bonus": 2,
+      "description_frequency": 20,
+      "player_descriptions": [
+        "You play a simple rhythm on the drum.",
+        "You strike a steady beat on the side drum.",
+        "Your drum beats with the cadence of an army on the march."
+      ],
+      "npc_descriptions": [ "play a simple rhythm on the drum.", "strike a steady beat on the side drum.", "the drumming of an army on the march." ]
+    },
+    "symbol": "-",
+    "description": "A handmade side drum with a shoulder strap, allowing you to wear it while playing.",
+    "price": 500,
+    "material": [ "wood", "leather" ],
+    "volume": 10,
+    "encumbrance": 10,
+    "bashing": 4,
+    "flags": [ "WAIST" ],
+    "coverage": 10,
+    "material_thickness": 2
   }
 ]

--- a/MST_Extra/items.json
+++ b/MST_Extra/items.json
@@ -580,5 +580,20 @@
     "addiction_potential": 1,
     "use_action": "ALCOHOL_WEAK",
     "flags": [ "EATEN_COLD" ]
+  },
+  {
+    "id": "bucket_log",
+    "type": "CONTAINER",
+    "name": "makeshift wooden bucket",
+    "description": "A large bucket for holding water, made from hollowing out a log and adding handles made of natural cordage.  Can hold 7 liters.",
+    "weight": "2725 g",
+    "volume": "10 L",
+    "price": 100,
+    "material": "wood",
+    "symbol": ")",
+    "color": "brown",
+    "contains": "7 L",
+    "watertight": true,
+    "qualities": [ [ "CONTAIN", 1 ] ]
   }
 ]

--- a/MST_Extra/recipes.json
+++ b/MST_Extra/recipes.json
@@ -910,5 +910,18 @@
       [ [ "honey_bottled", 3 ], [ "honey_glassed", 1 ], [ "sugar", 10 ] ],
       [ [ "wild_herbs", 10 ] ]
     ]
+  },
+  {
+    "type": "recipe",
+    "result": "bucket_log",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_CONTAINERS",
+    "skill_used": "fabrication",
+    "difficulty": 3,
+    "skills_required": [ "survival", 2 ],
+    "time": "45 m",
+    "autolearn": true,
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SAW_W", "level": 1 } ],
+    "components": [ [ [ "log", 1 ] ], [ [ "cordage", 3, "LIST" ] ] ]
   }
 ]

--- a/MST_Extra/recipes.json
+++ b/MST_Extra/recipes.json
@@ -837,11 +837,7 @@
       { "id": "CONTAIN", "level": 1 }
     ],
     "tools": [ [ [ "surface_heat", 3, "LIST" ] ] ],
-    "components": [
-      [ [ "water_clean", 1 ], [ "water", 1 ] ],
-      [ [ "lye_powder", 2 ], [ "aspirin", 2 ] ],
-      [ [ "cured_hide_small", 1 ] ]
-    ]
+    "components": [ [ [ "water_clean", 1 ], [ "water", 1 ] ], [ [ "lye_powder", 2 ], [ "aspirin", 2 ] ], [ [ "cured_hide_small", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -862,10 +858,57 @@
       { "id": "CONTAIN", "level": 1 }
     ],
     "tools": [ [ [ "surface_heat", 3, "LIST" ] ] ],
+    "components": [ [ [ "water_clean", 1 ], [ "water", 1 ] ], [ [ "lye_powder", 2 ], [ "aspirin", 2 ] ], [ [ "cured_pelt_small", 1 ] ] ]
+  },
+  {
+    "result": "side_drum_makeshift",
+    "type": "recipe",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TOOLS",
+    "skill_used": "survival",
+    "difficulty": 4,
+    "skills_required": [ "fabrication", 4 ],
+    "time": "90 m",
+    "autolearn": true,
+    "using": [ [ "sewing_standard", 25 ] ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SAW_W", "level": 1 }, { "id": "SEW", "level": 1 } ],
     "components": [
-      [ [ "water_clean", 1 ], [ "water", 1 ] ],
-      [ [ "lye_powder", 2 ], [ "aspirin", 2 ] ],
-      [ [ "cured_pelt_small", 1 ] ]
+      [ [ "cured_hide", 1 ], [ "tanned_hide", 1 ] ],
+      [ [ "cordage_short", 6, "LIST" ], [ "filament", 120, "LIST" ] ],
+      [ [ "log", 1 ] ]
+    ]
+  },
+  {
+    "type": "recipe",
+    "result": "pot_canning_clay",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_CONTAINERS",
+    "skill_used": "fabrication",
+    "skills_required": [ "survival", 2 ],
+    "difficulty": 4,
+    "time": "60 m",
+    "autolearn": true,
+    "using": [ [ "cordage_short", 2 ], [ "glazing", 2 ], [ "earthenware_firing", 140 ] ],
+    "components": [ [ [ "water", 2 ], [ "water_clean", 2 ] ], [ [ "clay_lump", 15 ] ] ]
+  },
+  {
+    "result": "posca",
+    "type": "recipe",
+    "category": "CC_FOOD",
+    "subcategory": "CSC_FOOD_DRINKS",
+    "skill_used": "cooking",
+    "difficulty": 1,
+    "time": "1 m",
+    "batch_time_factors": [ 80, 4 ],
+    "autolearn": true,
+    "result_mult": 5,
+    "qualities": [ { "id": "BOIL", "level": 1 } ],
+    "tools": [ [ [ "water_boiling_heat", 3, "LIST" ] ] ],
+    "components": [
+      [ [ "water", 4 ], [ "water_clean", 4 ] ],
+      [ [ "bum_wine", 6 ], [ "fruit_wine", 3 ], [ "dandelion_wine", 3 ], [ "pine_wine", 3 ] ],
+      [ [ "honey_bottled", 3 ], [ "honey_glassed", 1 ], [ "sugar", 10 ] ],
+      [ [ "wild_herbs", 10 ] ]
     ]
   }
 ]

--- a/MST_Extra/recipes.json
+++ b/MST_Extra/recipes.json
@@ -873,6 +873,7 @@
     "using": [ [ "sewing_standard", 25 ] ],
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SAW_W", "level": 1 }, { "id": "SEW", "level": 1 } ],
     "components": [
+      [ [ "water_clean", 1 ], [ "water", 1 ] ], 
       [ [ "cured_hide", 1 ], [ "tanned_hide", 1 ] ],
       [ [ "cordage_short", 6, "LIST" ], [ "filament", 120, "LIST" ] ],
       [ [ "log", 1 ] ]


### PR DESCRIPTION
* Side drums, idea here is use of a log for the drum body, cured hide or tanned hide for the skin, added cordage for lacing as well as a strap. Likely reasonably small, in the general vicinity of handheld water drums and tabors.
* A ceramic version of the canning pot.
* Posca! Idea came up quite some time ago as an added use for honey being slightly more accessible in MST Extra, had to revisit it and ensure the recipe created a reasonably sane range of nutrition close enough to the value of non-player-made versions. So long as you don't use Nuclear Honey at least, as I find out during testing: https://www.reddit.com/r/cataclysmdda/comments/d0nz3s/til_you_can_work_an_unlimited_amount_of_sugar/
* Makeshift buckets made from hollowing out a log. A proper stave-and-hoop bucket would be neat to add too, but this allows an additional option for medium-volume water storage at a point in progression where there are very few options available innawoods, and a proper bucket would be a pure flavor item given you'll get ahold of ceramics by the time you have an entry-level metalworking setup ready.