### PR TITLE
Obsolete borrowed items and recipes

### DIFF
--- a/MST_Extra/items/armor.json
+++ b/MST_Extra/items/armor.json
@@ -19,54 +19,6 @@
     "flags": [ "VARSIZE", "SUN_GLASSES", "WATERPROOF" ]
   },
   {
-    "id": "pack_basket",
-    "type": "ARMOR",
-    "name": "pack basket",
-    "description": "A large hand made straw basket, with shoulder straps to wear like a backpack.",
-    "weight": "300 g",
-    "volume": "8004 ml",
-    "price": 1000,
-    "to_hit": -1,
-    "material": [ "paper" ],
-    "symbol": "[",
-    "color": "light_gray",
-    "covers": [ "torso" ],
-    "coverage": 30,
-    "encumbrance": 12,
-    "pocket_data": [ { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "8 L", "max_contains_weight": "16 kg", "moves": 300 } ],
-    "material_thickness": 2,
-    "flags": [ "BELTED", "WATER_FRIENDLY" ]
-  },
-  {
-    "id": "sheath_birchbark",
-    "type": "ARMOR",
-    "name": "birchbark sheath",
-    "name_plural": "birchbark sheathes",
-    "description": "A hand made sheath made from birch bark, for holding knives and other small blades.  Activate to sheathe/draw a weapon.",
-    "weight": "200 g",
-    "volume": "500 ml",
-    "price": 1500,
-    "material": [ "paper" ],
-    "symbol": "|",
-    "color": "light_gray",
-    "covers": [ "leg_l", "leg_r" ],
-    "sided": true,
-    "coverage": 7,
-    "material_thickness": 1,
-    "pocket_data": [
-      {
-        "holster": true,
-        "max_contains_volume": "750 ml",
-        "max_contains_weight": "2 kg",
-        "max_item_length": "70 cm",
-        "moves": 3,
-        "flag_restriction": [ "SHEATH_KNIFE" ]
-      }
-    ],
-    "use_action": { "type": "holster", "holster_prompt": "Sheath knife", "holster_msg": "You sheath your %s" },
-    "flags": [ "WAIST", "OVERSIZE", "WATER_FRIENDLY" ]
-  },
-  {
     "id": "armwrap_leather",
     "type": "ARMOR",
     "name": "leather armwraps",

--- a/MST_Extra/obsolete.json
+++ b/MST_Extra/obsolete.json
@@ -191,5 +191,29 @@
     "result": "screwdriver_set",
     "id_suffix": "forged",
     "obsolete": true
+  },
+  {
+    "id": "pack_basket",
+    "type": "ARMOR",
+    "name": "pack basket",
+    "description": "A large hand made straw basket, with shoulder straps to wear like a backpack.",
+    "weight": "300 g",
+    "volume": "8004 ml",
+    "price": 1000,
+    "to_hit": -1,
+    "material": [ "paper" ],
+    "symbol": "[",
+    "color": "light_gray",
+    "covers": [ "torso" ],
+    "coverage": 30,
+    "encumbrance": 12,
+    "pocket_data": [ { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "8 L", "max_contains_weight": "16 kg", "moves": 300 } ],
+    "material_thickness": 2,
+    "flags": [ "BELTED", "WATER_FRIENDLY" ]
+  },
+  {
+    "type": "recipe",
+    "result": "pack_basket",
+    "obsolete": true
   }
 ]

--- a/MST_Extra/recipes/recipe_armor.json
+++ b/MST_Extra/recipes/recipe_armor.json
@@ -16,37 +16,6 @@
     ]
   },
   {
-    "result": "pack_basket",
-    "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
-    "category": "CC_ARMOR",
-    "subcategory": "CSC_ARMOR_STORAGE",
-    "skill_used": "tailor",
-    "difficulty": 2,
-    "skills_required": [ "survival", 1 ],
-    "time": "24 m",
-    "autolearn": true,
-    "proficiencies": [ { "proficiency": "prof_basketweaving", "required": false, "time_multiplier": 3 } ],
-    "components": [ [ [ "straw_pile", 10 ], [ "birchbark", 12 ] ], [ [ "cordage", 2, "LIST" ], [ "filament", 90, "LIST" ] ] ]
-  },
-  {
-    "result": "sheath_birchbark",
-    "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
-    "category": "CC_ARMOR",
-    "subcategory": "CSC_ARMOR_STORAGE",
-    "skill_used": "tailor",
-    "difficulty": 3,
-    "skills_required": [ "survival", 1 ],
-    "time": "20 m",
-    "reversible": true,
-    "decomp_learn": 3,
-    "autolearn": true,
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "proficiencies": [ { "proficiency": "prof_basketweaving", "required": false, "time_multiplier": 3 } ],
-    "components": [ [ [ "birchbark", 3 ] ] ]
-  },
-  {
     "result": "armwrap_leather",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",


### PR DESCRIPTION
Two items in https://github.com/CleverRaven/Cataclysm-DDA/pull/45724 serve the exact same function ~~and have very similar JSON, to two items in this mod~~ so they won't be necessary in MST Extra anymore.

Setting aside this PR for after this is merged, will have to look into porting it over to BN too.

EDIT: hi yes I'm a moron