### PR TITLE
Fix for leather curtains in the DDA version

### DIFF
--- a/MST_Extra/furniture_and_terrain/terrain.json
+++ b/MST_Extra/furniture_and_terrain/terrain.json
@@ -183,7 +183,7 @@
       "ter_set": "t_dirt",
       "items": [ { "item": "stick", "count": 1 }, { "item": "leather_tarp", "count": 1 }, { "item": "withered", "count": 12 } ]
     },
-    "close": "t_door_curtain_c",
+    "close": "t_door_curtain_leather_c",
     "bash": {
       "str_min": 1,
       "str_max": 8,

--- a/MST_Extra/furniture_and_terrain/terrain.json
+++ b/MST_Extra/furniture_and_terrain/terrain.json
@@ -174,7 +174,7 @@
     "name": "open leather door curtain",
     "description": "Hides from an animal hung up as a door.  Could be easily taken down for supplies or placed somewhere else.  These curtains are open, bundled and tied next to the doorway.",
     "symbol": "'",
-    "looks_like": "t_door_curtain_leather_c",
+    "looks_like": "t_door_curtain_o",
     "color": "dark_gray",
     "move_cost": 2,
     "roof": "t_flat_roof",


### PR DESCRIPTION
Clears a warning from the open leather door curtain closing to the wrong thing and fixes its looks_like. The values are the same as the BN version of the file now.

```
opening terrain t_door_curtain_leather_o for t_door_curtain_leather_c doesn't reciprocate
closing terrain t_door_curtain_c for t_door_curtain_leather_o doesn't reciprocate
```