### PR TITLE
Remove erroneous initial charges from side drum.

### DIFF
--- a/MST_Extra/items/tool_armor.json
+++ b/MST_Extra/items/tool_armor.json
@@ -6,7 +6,6 @@
     "category": "tools",
     "weight": "1800 g",
     "color": "brown",
-    "initial_charges": 1,
     "use_action": {
       "type": "musical_instrument",
       "speed_penalty": 15,


### PR DESCRIPTION
Recent changes to CDDA cause this error:

```
12:17:47.131 ERROR : src/main_menu.cpp:1144 [bool main_menu::load_character_tab(bool)] Error: Json error: home/user/.cataclysm-dda/mods/MST_Extra/items/tool_armor.json:9:23: initial_charges is larger than max_charges

    "weight": "1800 g",
    "color": "brown",
    "initial_charges":
                      ^
                       1,
    "use_action": {
      "type": "musical_instrument",

```

I just remove that line.

The drum still works according to my testing.