### PR TITLE
Added pocket data and charge use, removed max charges

### DIFF
--- a/MST_Extra/items/tools.json
+++ b/MST_Extra/items/tools.json
@@ -348,7 +348,8 @@
     "color": "light_gray",
     "sub": "water_purifier",
     "ammo": "charcoal",
-    "max_charges": 500,
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "charcoal": 500 } } ],
+    "charges_per_use": 1,
     "flags": [ "ALLOWS_REMOTE_USE" ]
   },
   {


### PR DESCRIPTION
After updating cdda to 0.F-2626-ga1d4e98112 and loading a game got an error about this item needing pocket data so added it.

Not sure if the ammo line is still relevant.

For testing I spawned in one of the items, it came with full charges.  I made some clean water successfully and once charge was deducted.  Also reloading/unloading worked.