### PR TITLE
Add license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,1 @@
+More Survival Tools Extra is licensed under the Creative Commons Attribution-ShareAlike 3.0 Unported License. To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/3.0/ or send a letter to Creative Commons, 444 Castro Street, Suite 900, Mountain View, California, 94041, USA.


### PR DESCRIPTION
This mod is a derivative mod work of a mod that lived in the DDA repo, and so is licensed under the CC-BY-SA 3.0 license, as DDA is. Introduced to the DDA repo in https://github.com/CleverRaven/Cataclysm-DDA/pull/11707.

Copy the license from DDA, and make a few changes to make it relevant.

Bright Nights is also licensed under CC-BY-SA 3.0, so this will work for both versions.