### PR TITLE
Fix pemmican not being batcheable, add new components and recipe

### DIFF
--- a/MST_Extra/recipes/recipe_overrides.json
+++ b/MST_Extra/recipes/recipe_overrides.json
@@ -138,29 +138,23 @@
   {
     "type": "recipe",
     "result": "pemmican",
-    "activity_level": "LIGHT_EXERCISE",
-    "category": "CC_FOOD",
-    "subcategory": "CSC_FOOD_MEAT",
-    "skill_used": "cooking",
-    "difficulty": 5,
-    "charges": 4,
-    "time": "45 m",
-    "autolearn": true,
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "tools": [ [ [ "surface_heat", 20, "LIST" ] ] ],
+    "copy-from": "pemmican",
     "components": [
-      [ [ "edible_tallow_lard", 1, "LIST" ] ],
+      [ [ "edible_tallow_lard", 2, "LIST" ], [ "ghee", 2 ] ],
       [
         [ "jerky", 2 ],
-        [ "jerky_offal", 2 ],
         [ "dry_meat", 2 ],
         [ "meat_smoked", 2 ],
         [ "dry_fish", 2 ],
-        [ "salted_fish", 2 ],
-        [ "fish_smoked", 2 ]
+        [ "fish_smoked", 2 ],
+        [ "dry_lobster", 2 ],
+        [ "lobster_smoked", 2 ],
+        [ "jerky_offal", 2 ],
+        [ "salted_fish", 2 ]
       ],
       [
         [ "dry_veggy", 2 ],
+        [ "dry_corn", 2 ],
         [ "dry_fruit", 2 ],
         [ "dry_mushroom", 2 ],
         [ "juice_pulp", 4 ],
@@ -174,8 +168,29 @@
         [ "cranberries", 1 ],
         [ "irradiated_raspberries", 1 ],
         [ "raspberries", 1 ],
+        [ "wintergreen_berry", 4 ],
+        [ "m_stellatum_berries", 4 ],
         [ "irradiated_blackberries", 1 ],
         [ "blackberries", 1 ]
+      ]
+    ]
+  },
+  {
+    "type": "recipe",
+    "result": "pemmican_meat",
+    "copy-from": "pemmican_meat",
+    "components": [
+      [ [ "edible_tallow_lard", 2, "LIST" ], [ "ghee", 2 ] ],
+      [
+        [ "jerky", 2 ],
+        [ "dry_meat", 2 ],
+        [ "meat_smoked", 2 ],
+        [ "dry_fish", 2 ],
+        [ "fish_smoked", 2 ],
+        [ "dry_lobster", 2 ],
+        [ "lobster_smoked", 2 ],
+        [ "jerky_offal", 2 ],
+        [ "salted_fish", 2 ]
       ]
     ]
   },


### PR DESCRIPTION
The pemmican recipe was missing the batch declaration, so instead I `copy-from`ed it, adding the extra MST_extra extra components.