### PR TITLE
Phase out items being mainlined in BN

### DIFF
--- a/MST_Extra_BN/item_groups.json
+++ b/MST_Extra_BN/item_groups.json
@@ -45,53 +45,8 @@
     "items": [ [ "oil_lamp_clay", 20 ] ]
   },
   {
-    "id": "kitchen",
-    "type": "item_group",
-    "ammo": 75,
-    "magazine": 100,
-    "subtype": "distribution",
-    "entries": [
-      { "item": "bread_garlic", "prob": 7 },
-      { "item": "potted_meat", "prob": 2, "charges": 12, "container-item": "jar_3l_glass_sealed" }
-    ]
-  },
-  {
-    "id": "groce_bread",
-    "type": "item_group",
-    "items": [ [ "bread_garlic", 20 ] ]
-  },
-  {
-    "id": "restaur_kitchen",
-    "type": "item_group",
-    "items": [ [ "bread_garlic", 14 ] ]
-  },
-  {
     "id": "vet_utility",
     "type": "item_group",
     "items": [ [ "jerky_offal", 20 ] ]
-  },
-  {
-    "type": "item_group",
-    "id": "butcher_meat",
-    "subtype": "distribution",
-    "entries": [ { "item": "potted_meat", "prob": 1 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "preserved_food",
-    "subtype": "distribution",
-    "entries": [ { "item": "potted_meat", "prob": 20, "charges": 12, "container-item": "jar_3l_glass_sealed" } ]
-  },
-  {
-    "type": "item_group",
-    "id": "foodintincan",
-    "subtype": "distribution",
-    "entries": [ { "item": "potted_meat", "prob": 1 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "cannedfood",
-    "subtype": "distribution",
-    "entries": [ { "item": "potted_meat", "prob": 4, "charges": 12, "container-item": "jar_3l_glass_sealed" } ]
   }
 ]

--- a/MST_Extra_BN/items/comestibles.json
+++ b/MST_Extra_BN/items/comestibles.json
@@ -48,41 +48,6 @@
     "flags": [ "NPC_SAFE", "NUTRIENT_OVERRIDE" ]
   },
   {
-    "type": "COMESTIBLE",
-    "id": "garlic_roasted",
-    "copy-from": "garlic",
-    "name": { "str_sp": "roasted garlic" },
-    "spoils_in": "180 days",
-    "quench": -1,
-    "description": "Cloves of garlic, lightly seasoned and roasted.",
-    "price": 800,
-    "material": [ "garlic" ],
-    "fun": 1
-  },
-  {
-    "type": "COMESTIBLE",
-    "id": "bread_garlic",
-    "copy-from": "bread",
-    "name": { "str_sp": "garlic bread" },
-    "calories": 105,
-    "quench": -2,
-    "description": "Bread cooked with garlic and seasonings.",
-    "price": 100,
-    "material": [ "wheat", "garlic" ],
-    "vitamins": [ [ "vitC", 6 ], [ "calcium", 12 ], [ "iron", 5 ] ],
-    "charges": 3,
-    "fun": 3
-  },
-  {
-    "type": "COMESTIBLE",
-    "id": "chili_pepper_roasted",
-    "copy-from": "chili_pepper",
-    "name": { "str": "roasted chili pepper" },
-    "description": "Spicy chili pepper, lightly seasoned and roasted.",
-    "charges": 1,
-    "fun": 1
-  },
-  {
     "id": "makeshift_poultice",
     "type": "COMESTIBLE",
     "comestible_type": "MED",
@@ -127,19 +92,6 @@
     "fun": 0
   },
   {
-    "type": "COMESTIBLE",
-    "id": "porridge_cooked",
-    "copy-from": "wheat",
-    "name": { "str_sp": "porridge" },
-    "weight": "247 g",
-    "spoils_in": "10 days",
-    "comestible_type": "FOOD",
-    "symbol": "%",
-    "description": "Simple fare made from cooking wheat or barley, bland but filling.",
-    "flags": [ "EATEN_HOT" ],
-    "fun": -1
-  },
-  {
     "id": "jerky_offal",
     "copy-from": "jerky",
     "type": "COMESTIBLE",
@@ -171,26 +123,5 @@
     "//": "Not millable as it requires a bit more drying to make into flour, and there may be technical issues if allowed to process less calorie-dense material into flour.",
     "flags": [ "EDIBLE_FROZEN", "NUTRIENT_OVERRIDE" ],
     "vitamins": [ [ "vitC", 1 ], [ "vitA", 3 ] ]
-  },
-  {
-    "type": "COMESTIBLE",
-    "id": "potted_meat",
-    "copy-from": "pemmican",
-    "name": { "str_sp": "potted meat" },
-    "conditional_names": [
-      { "type": "FLAG", "condition": "CANNIBALISM", "name": { "str_sp": "potted person" } },
-      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "potted freak" } }
-    ],
-    "weight": "155 g",
-    "container": "can_medium",
-    "calories": 452,
-    "charges": 2,
-    "description": "Meat cooked and preserved in butter or melted fat, a form of food preservation from the days before canning.  Also known as confit.  Rich and fattening, it will last for a long time.",
-    "price": "12 USD",
-    "price_postapoc": "4 USD",
-    "material": [ "flesh" ],
-    "vitamins": [ [ "vitA", 7 ], [ "vitC", 16 ], [ "calcium", 2 ], [ "iron", 69 ], [ "vitB", 781 ] ],
-    "fun": 1,
-    "extend": { "flags": [ "EATEN_HOT" ] }
   }
 ]

--- a/MST_Extra_BN/recipes/recipe_food.json
+++ b/MST_Extra_BN/recipes/recipe_food.json
@@ -129,84 +129,6 @@
   },
   {
     "type": "recipe",
-    "result": "garlic_roasted",
-    "category": "CC_FOOD",
-    "subcategory": "CSC_FOOD_VEGGI",
-    "skill_used": "cooking",
-    "difficulty": 1,
-    "time": "15 m",
-    "batch_time_factors": [ 67, 5 ],
-    "autolearn": true,
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "COOK", "level": 2 } ],
-    "tools": [ [ [ "surface_heat", 5, "LIST" ] ] ],
-    "components": [
-      [ [ "garlic", 1 ], [ "garlic_clove", 6 ] ],
-      [
-        [ "salt", 5 ],
-        [ "seasoning_salt", 5 ],
-        [ "pepper", 5 ],
-        [ "chilly-p", 5 ],
-        [ "curry_powder", 5 ],
-        [ "seasoning_italian", 5 ],
-        [ "wild_herbs", 5 ]
-      ]
-    ]
-  },
-  {
-    "type": "recipe",
-    "result": "bread_garlic",
-    "category": "CC_FOOD",
-    "subcategory": "CSC_FOOD_VEGGI",
-    "skill_used": "cooking",
-    "difficulty": 2,
-    "time": "20 m",
-    "batch_time_factors": [ 67, 5 ],
-    "autolearn": true,
-    "charges": 1,
-    "book_learn": [ [ "cookbook_italian", 1 ] ],
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "COOK", "level": 2 } ],
-    "tools": [ [ [ "surface_heat", 10, "LIST" ] ] ],
-    "components": [
-      [ [ "flatbread", 1 ], [ "bread", 1 ], [ "cornbread", 1 ], [ "wastebread", 1 ] ],
-      [ [ "garlic_roasted", 1 ] ],
-      [
-        [ "salt", 10 ],
-        [ "seasoning_salt", 10 ],
-        [ "pepper", 10 ],
-        [ "chilly-p", 10 ],
-        [ "curry_powder", 10 ],
-        [ "seasoning_italian", 10 ],
-        [ "wild_herbs", 10 ]
-      ]
-    ]
-  },
-  {
-    "type": "recipe",
-    "result": "chili_pepper_roasted",
-    "category": "CC_FOOD",
-    "subcategory": "CSC_FOOD_VEGGI",
-    "skill_used": "cooking",
-    "difficulty": 1,
-    "time": "15 m",
-    "batch_time_factors": [ 67, 5 ],
-    "autolearn": true,
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "COOK", "level": 2 } ],
-    "tools": [ [ [ "surface_heat", 5, "LIST" ] ] ],
-    "components": [
-      [ [ "chili_pepper", 1 ] ],
-      [
-        [ "salt", 5 ],
-        [ "seasoning_salt", 5 ],
-        [ "pepper", 5 ],
-        [ "chilly-p", 5 ],
-        [ "curry_powder", 5 ],
-        [ "seasoning_italian", 5 ],
-        [ "wild_herbs", 5 ]
-      ]
-    ]
-  },
-  {
-    "type": "recipe",
     "result": "salt",
     "id_suffix": "distillation",
     "byproducts": [ [ "water_clean" ] ],
@@ -259,19 +181,6 @@
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "COOK", "level": 1 } ],
     "tools": [ [ [ "surface_heat", 5, "LIST" ] ] ],
     "components": [ [ [ "cattail_rhizome", 1 ] ] ]
-  },
-  {
-    "type": "recipe",
-    "result": "porridge_cooked",
-    "category": "CC_FOOD",
-    "subcategory": "CSC_FOOD_VEGGI",
-    "skill_used": "cooking",
-    "difficulty": 1,
-    "time": "9 m",
-    "autolearn": true,
-    "qualities": [ { "id": "COOK", "level": 2 } ],
-    "tools": [ [ [ "surface_heat", 2, "LIST" ] ] ],
-    "components": [ [ [ "wheat", 1 ], [ "barley", 1 ] ], [ [ "water", 1 ], [ "water_clean", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -364,28 +273,5 @@
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "CONTAIN", "level": 1 } ],
     "tools": [ [ [ "surface_heat", 10, "LIST" ] ], [ [ "mortar_pestle", -1 ] ] ],
     "components": [ [ [ "tree_bacon", 1 ] ] ]
-  },
-  {
-    "type": "recipe",
-    "result": "potted_meat",
-    "category": "CC_FOOD",
-    "subcategory": "CSC_FOOD_MEAT",
-    "skill_used": "cooking",
-    "difficulty": 3,
-    "time": "60 m",
-    "batch_time_factors": [ 80, 4 ],
-    "autolearn": [ [ "cooking", 4 ] ],
-    "book_learn": [ [ "family_cookbook", 3 ], [ "scots_cookbook", 2 ] ],
-    "qualities": [
-      { "id": "CUT", "level": 1 },
-      { "id": "BOIL", "level": 1 },
-      { "id": "COOK", "level": 2 },
-      { "id": "CONTAIN", "level": 1 }
-    ],
-    "tools": [ [ [ "surface_heat", 20, "LIST" ] ] ],
-    "components": [
-      [ [ "edible_tallow_lard", 1, "LIST" ], [ "any_butter", 5, "LIST" ] ],
-      [ [ "meat_red_raw", 1, "LIST" ], [ "fish", 1 ], [ "meat_offal", 1, "LIST" ] ]
-    ]
   }
 ]


### PR DESCRIPTION
Set aside as a self-PR for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2608 is merged, which will make the above items and recipes mainline content (with same IDs) and thus free to delete from here outright.