### PR TITLE
Clay lamp oil cooker

### DIFF
--- a/MST_Extra_BN/items/tools.json
+++ b/MST_Extra_BN/items/tools.json
@@ -182,6 +182,24 @@
     "flags": [ "LIGHT_9", "TRADER_AVOID", "FIRE", "ALLOWS_REMOTE_USE", "WATER_EXTINGUISH" ]
   },
   {
+    "id": "oil_cooker_clay",
+    "copy-from": "oil_cooker",
+    "sub": "hotplate",
+    "type": "TOOL",
+    "name": { "str": "clay lamp oil cooker", "str_pl": "clay lamp oil cookers" },
+    "description": "This is a small clay container with a wick, an ancient form of oil lamp.  It does not provide much light, but it lasts a long time.  Use it to turn it on.",
+    "weight": "620 g",
+    "volume": "250 ml",
+    "price": 800,
+    "material": [ "clay" ],
+    "color": "brown",
+    "ammo": "lamp_oil",
+    "initial_charges": 250,
+    "max_charges": 250,
+    "charges_per_use": 1,
+    "use_action": "HOTPLATE"
+  },
+  {
     "id": "tinderbox_clay",
     "copy-from": "tinderbox",
     "sub": "tinderbox",

--- a/MST_Extra_BN/recipes/recipe_other.json
+++ b/MST_Extra_BN/recipes/recipe_other.json
@@ -472,6 +472,19 @@
   },
   {
     "type": "recipe",
+    "result": "oil_cooker_clay",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TOOLS",
+    "skill_used": "fabrication",
+    "skills_required": [ "survival", 1 ],
+    "difficulty": 2,
+    "time": "30 m",
+    "autolearn": true,
+    "using": [ [ "earthenware_firing", 70 ] ],
+    "components": [ [ [ "water", 1 ], [ "water_clean", 1 ] ], [ [ "clay_lump", 3 ] ], [ [ "cordage_short", 2, "LIST" ], [ "rag", 1 ] ] ]
+  },
+  {
+    "type": "recipe",
     "result": "tinderbox_clay",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_TOOLS",


### PR DESCRIPTION
#### SUMMARY

Summary: Content "Adds a clay lamp oil cooker."

#### Purpose of change

I noticed in innawoods starts you need a pilot light to use lamp oil for cooking which is impossible to get purely innawoods. This adds a clay lamp oil cooker based on the clay oil lamp and lamp oil cooker.

#### Describe the solution

Adds said item plus a recipe for it. The recipe is exactly the same because I figure it's just you using the lamp to cook. The item has the same charge capacity as the clay lamp.

#### Describe alternatives you've considered

Different crafting costs, different capacity.

#### Testing

I loaded the game, made it. It worked.

#### Additional Context

Change the balance if you feel its necessary.