### PR TITLE
Add clay jars for foodstuff recipes

### DIFF
--- a/MST_Extra_BN/items/bread.json
+++ b/MST_Extra_BN/items/bread.json
@@ -15,7 +15,7 @@
     "symbol": "%",
     "color": "white",
     "use_action": {
-      "target": "sourdough_starter",
+      "target": "jar_clay_sourdough_starter",
       "msg": "After feeding it and caring for it for weeks, your sourdough starter is finally ready for the big leagues.",
       "moves": 50,
       "type": "delayed_transform",
@@ -39,7 +39,7 @@
     "symbol": "%",
     "color": "white",
     "use_action": {
-      "target": "sourdough_starter",
+      "target": "jar_clay_sourdough_starter",
       "msg": "The starter is now stinky and bubbly, and looks ready for cooking.",
       "moves": 50,
       "type": "delayed_transform",

--- a/MST_Extra_BN/items/bread.json
+++ b/MST_Extra_BN/items/bread.json
@@ -1,0 +1,90 @@
+[
+  {
+    "id": "jar_clay_sourdough_young",
+    "type": "GENERIC",
+    "category": "food",
+    "name": { "str": "clay jar of juvenile sourdough starter" },
+    "description": "This clay jar contains a floury paste that is slowly going bad.  Someday it will be sourdough.",
+    "weight": "52 g",
+    "volume": "250 ml",
+    "price": 10,
+    "price_postapoc": 10,
+    "bashing": 8,
+    "material": [ "clay", "wheat" ],
+    "looks_like": "jar_clay",
+    "symbol": "%",
+    "color": "white",
+    "use_action": {
+      "target": "sourdough_starter",
+      "msg": "After feeding it and caring for it for weeks, your sourdough starter is finally ready for the big leagues.",
+      "moves": 50,
+      "type": "delayed_transform",
+      "transform_age": 200000,
+      "not_ready_msg": "You've been caring for your starter for a while, but it's going to need longer before you can do anything tasty with it."
+    }
+  },
+  {
+    "id": "jar_clay_sourdough_split",
+    "type": "GENERIC",
+    "category": "food",
+    "name": { "str": "freshly fed sourdough starter in a clay jar" },
+    "description": "This clay jar contains a floury paste with sourdough starter mixed in.  It needs a few hours to recover its strength before it can be used again.",
+    "weight": "52 g",
+    "volume": "250 ml",
+    "price": 10,
+    "price_postapoc": 10,
+    "bashing": 8,
+    "material": [ "glass", "wheat" ],
+    "looks_like": "jar_glass",
+    "symbol": "%",
+    "color": "white",
+    "use_action": {
+      "target": "sourdough_starter",
+      "msg": "The starter is now stinky and bubbly, and looks ready for cooking.",
+      "moves": 50,
+      "type": "delayed_transform",
+      "transform_age": 180000,
+      "not_ready_msg": "The starter isn't quite ready to go."
+    }
+  },
+  {
+    "id": "jar_clay_sourdough_young",
+    "type": "GENERIC",
+    "category": "food",
+    "name": { "str": "juvenile sourdough starter in clay jar" },
+    "description": "This jar contains a floury paste that is slowly going bad.  Someday it will be sourdough.",
+    "weight": "52 g",
+    "volume": "250 ml",
+    "price": 10,
+    "price_postapoc": 10,
+    "bashing": 8,
+    "material": [ "clay", "wheat" ],
+    "looks_like": "jar_glass",
+    "symbol": "%",
+    "color": "white",
+    "use_action": {
+      "target": "jar_clay_sourdough_starter",
+      "msg": "After feeding it and caring for it for weeks, your sourdough starter is finally ready for the big leagues.",
+      "moves": 50,
+      "type": "delayed_transform",
+      "transform_age": 200000,
+      "not_ready_msg": "You've been caring for your starter for a while, but it's going to need longer before you can do anything tasty with it."
+    }
+  },
+  {
+    "id": "jar_clay_sourdough_starter",
+    "type": "GENERIC",
+    "category": "food",
+    "name": { "str": "sourdough starter in a clay jar" },
+    "description": "This clay jar contains a precious mix of flour, water, molds and bacteria from the air.  When you add flour and water to it, after a few hours it froths and rises.",
+    "weight": "52 g",
+    "looks_like": "jar_clay",
+    "volume": "250 ml",
+    "price": 50,
+    "price_postapoc": 10,
+    "bashing": 8,
+    "material": [ "clay", "wheat" ],
+    "symbol": "%",
+    "color": "white"
+  }
+]

--- a/MST_Extra_BN/items/comestibles.json
+++ b/MST_Extra_BN/items/comestibles.json
@@ -102,5 +102,29 @@
     "healthy": -1,
     "calories": 92,
     "proportional": { "price": 0.8 }
+  },
+  {
+    "id": "jar_clay_sourdough_young",
+    "type": "GENERIC",
+    "category": "food",
+    "name": { "str": "juvenile sourdough starter in a clay jar" },
+    "description": "This clay jar contains a floury paste that is slowly going bad.  Someday it will be sourdough.",
+    "weight": "52 g",
+    "volume": "250 ml",
+    "price": 10,
+    "price_postapoc": 10,
+    "bashing": 8,
+    "material": [ "clay", "wheat" ],
+    "looks_like": "jar_clay",
+    "symbol": "%",
+    "color": "white",
+    "use_action": {
+      "target": "sourdough_starter",
+      "msg": "After feeding it and caring for it for weeks, your sourdough starter is finally ready for the big leagues.",
+      "moves": 50,
+      "type": "delayed_transform",
+      "transform_age": 200000,
+      "not_ready_msg": "You've been caring for your starter for a while, but it's going to need longer before you can do anything tasty with it."
+    }
   }
 ]

--- a/MST_Extra_BN/items/comestibles.json
+++ b/MST_Extra_BN/items/comestibles.json
@@ -119,7 +119,7 @@
     "symbol": "%",
     "color": "white",
     "use_action": {
-      "target": "sourdough_starter",
+      "target": "jar_clay_sourdough_starter",
       "msg": "After feeding it and caring for it for weeks, your sourdough starter is finally ready for the big leagues.",
       "moves": 50,
       "type": "delayed_transform",

--- a/MST_Extra_BN/items/cooking.json
+++ b/MST_Extra_BN/items/cooking.json
@@ -1,0 +1,176 @@
+[
+{
+    "id": "jar_clay_yeast",
+    "type": "GENERIC",
+    "name": { "str_sp": "sealed yeast culture" },
+    "description": "A sealed clay jar holding sanitized yeast wort.  You may harvest the yeast inside when it's done culturing.",
+    "copy-from": "jar_clay",
+    "use_action": {
+      "target": "yeast",
+      "msg": "You open the clay jar and harvest the culture.",
+      "container": "jar_clay",
+      "target_charges": 10,
+      "moves": 50,
+      "type": "delayed_transform",
+      "transform_age": 43200,
+      "not_ready_msg": "The yeast isn't done culturing yet."
+    }
+  },
+  {
+    "id": "jar_clay_wild_yeast",
+    "type": "GENERIC",
+    "name": { "str_sp": "sealed wild yeast culture" },
+    "description": "Mixture of water, sugar and fruits with some naturally occuring yeast in a clay jar, that will eventually produce a more sizeable yeast culture.",
+    "copy-from": "jar_clay",
+    "use_action": {
+      "target": "yeast",
+      "msg": "You open the clay jar and harvest the culture.",
+      "container": "jar_clay",
+      "target_charges": 2,
+      "moves": 50,
+      "type": "delayed_transform",
+      "transform_age": 259200,
+      "not_ready_msg": "The yeast isn't done culturing yet."
+    }
+  },
+  {
+    "id": "jar_clay_eggs_ferment",
+    "type": "GENERIC",
+    "category": "food",
+    "name": { "str": "fermenting eggs jar" },
+    "description": "This clay jar contains a batch of eggs in a pickling solution.  You can seal up the clay jar once the process is completed.",
+    "weight": "52 g",
+    "volume": "250 ml",
+    "price": 10,
+    "price_postapoc": 10,
+    "bashing": 8,
+    "material": [ "clay", "egg" ],
+    "symbol": "%",
+    "color": "white",
+    "use_action": {
+      "target": "jar_clay_eggs_pickled",
+      "msg": "You examine the batch and see that the pickling solution has done its job, so you seal the clay jar up for storage.",
+      "moves": 50,
+      "type": "delayed_transform",
+      "transform_age": 33600,
+      "not_ready_msg": "The eggs are not done yet."
+    }
+  },
+    {
+    "id": "jar_clay_eggs_pickled",
+    "type": "GENERIC",
+    "category": "food",
+    "name": { "str": "sealed clay jar of eggs", "str_pl": "sealed clay jars of eggs" },
+    "description": "This is a sealed clay jar containing pickled eggs.  Use to open and eat to enjoy.",
+    "weight": "1750 g",
+    "volume": "500 ml",
+    "price": 650,
+    "price_postapoc": 10,
+    "bashing": 4,
+    "material": [ "clay", "veggy" ],
+    "symbol": "%",
+    "color": "green",
+    "use_action": {
+      "target": "pickled_egg",
+      "msg": "You open the jar, exposing it to the atmosphere.",
+      "container": "jar_clay",
+      "target_charges": 6,
+      "menu_text": "Open jar",
+      "type": "transform"
+    }
+  },
+  {
+    "id": "jar_clay_sauerkraut_ferment",
+    "type": "GENERIC",
+    "category": "food",
+    "name": { "str": "fermenting sauerkraut" },
+    "description": "This clay jar contains a batch of sauerkraut set to ferment.  You can seal up the clay jar once the process is completed.",
+    "weight": "1750 g",
+    "volume": "500 ml",
+    "price": 10,
+    "price_postapoc": 10,
+    "bashing": 4,
+    "material": [ "clay", "veggy" ],
+    "symbol": "%",
+    "color": "white",
+    "use_action": {
+      "target": "jar_clay_sauerkraut_pickled",
+      "msg": "You test the batch, and it tastes good, so you seal the clay jar up for storage.",
+      "moves": 50,
+      "type": "delayed_transform",
+      "transform_age": 33600,
+      "not_ready_msg": "The sauerkraut isn't done fermenting yet.",
+      "//": "2 1/3 days, from the suggested recipie of 1 rl week"
+    }
+  },
+  {
+    "id": "jar_clay_sauerkraut_pickled",
+    "type": "GENERIC",
+    "category": "food",
+    "name": { "str": "sealed clay jar of sauerkraut", "str_pl": "sealed clay jars of sauerkraut" },
+    "description": "This is a sealed clay jar containing sauerkraut.  Use to open and eat to enjoy.",
+    "weight": "1750 g",
+    "volume": "500 ml",
+    "price": 650,
+    "price_postapoc": 10,
+    "bashing": 4,
+    "material": [ "clay", "veggy" ],
+    "symbol": "%",
+    "color": "green",
+    "use_action": {
+      "target": "sauerkraut",
+      "msg": "You open the jar, exposing it to the atmosphere.",
+      "container": "jar_clay",
+      "target_charges": 4,
+      "menu_text": "Open jar",
+      "type": "transform"
+    }
+  },
+  {
+    "id": "jar_clay_pickles_ferment",
+    "type": "GENERIC",
+    "category": "food",
+    "name": { "str": "fermenting pickle in clay jar" },
+    "description": "This clay jar contains a batch of pickles set to ferment.  You can seal up the clay jar once the process is completed.",
+    "weight": "52 g",
+    "volume": "250 ml",
+    "price": 10,
+    "price_postapoc": 10,
+    "bashing": 8,
+    "material": [ "clay", "veggy" ],
+    "symbol": "%",
+    "color": "white",
+    "use_action": {
+      "target": "jar_clay_pickles_pickled",
+      "msg": "You test the batch, and it tastes good, so you seal the clay jar up for storage.",
+      "moves": 50,
+      "type": "delayed_transform",
+      "transform_age": 33600,
+      "not_ready_msg": "The pickles are not done fermenting yet.",
+      "//": "2 1/3 days, from the suggested recipie of 1 rl week"
+    }
+  },
+  {
+    "id": "jar_clay_pickles_pickled",
+    "type": "GENERIC",
+    "category": "food",
+    "name": { "str": "sealed clay jar of pickles", "str_pl": "sealed clay jars of pickles" },
+    "description": "This is a sealed clay jar containing pickles.  Use to open and eat to enjoy.",
+    "weight": "1750 g",
+    "volume": "500 ml",
+    "price": 650,
+    "price_postapoc": 10,
+    "bashing": 4,
+    "material": [ "clay", "veggy" ],
+    "symbol": "%",
+    "color": "green",
+    "use_action": {
+      "target": "pickle",
+      "msg": "You open the jar, exposing it to the atmosphere.",
+      "container": "jar_clay",
+      "target_charges": 6,
+      "menu_text": "Open jar",
+      "type": "transform"
+    }
+  }
+]

--- a/MST_Extra_BN/items/veggy_dishes.json
+++ b/MST_Extra_BN/items/veggy_dishes.json
@@ -1,0 +1,14 @@
+[
+  {
+    "type": "COMESTIBLE",
+    "id": "jar_clay_veggy_pickled",
+    "name": { "str": "clay jar of pickled veggy", "str_pl": "clay jar of pickled veggies" },
+    "copy-from": "veggy",
+    "color": "light_green",
+    "spoils_in": "30 days",
+    "container": "jar_clay_sealed",
+    "description": "This is a serving of crisply brined and canned vegetable matter.  Tasty and nutritious.",
+    "price": 250,
+    "fun": 7
+  }
+]

--- a/MST_Extra_BN/recipes/recipe_bread.json
+++ b/MST_Extra_BN/recipes/recipe_bread.json
@@ -1,0 +1,28 @@
+[
+  {
+    "type": "recipe",
+    "result": "jar_clay_sourdough_split",
+    "category": "CC_FOOD",
+    "subcategory": "CSC_FOOD_BREAD",
+    "skill_used": "cooking",
+    "difficulty": 1,
+    "time": "5 m",
+    "result_mult": 2,
+    "autolearn": true,
+    "qualities": [ { "id": "CONTAIN", "level": 1 } ],
+    "components": [ [ [ "water", 1 ], [ "water_clean", 1 ] ], [ [ "jar_clay", 1 ] ], [ [ "flour", 4 ] ], [ [ "jar_clay_sourdough_starter", 1 ] ] ]
+  },
+    {
+    "type": "recipe",
+    "result": "jar_clay_sourdough_young",
+    "category": "CC_FOOD",
+    "subcategory": "CSC_FOOD_BREAD",
+    "skill_used": "cooking",
+    "difficulty": 5,
+    "time": "10 m",
+    "//": "Making the very first starter is a lot more finnicky than splitting it once it's mature.",
+    "autolearn": true,
+    "qualities": [ { "id": "CONTAIN", "level": 1 } ],
+    "components": [ [ [ "water", 1 ], [ "water_clean", 1 ] ], [ [ "jar_clay", 1 ] ], [ [ "flour", 4 ] ] ]
+  }
+]

--- a/MST_Extra_BN/recipes/recipe_other.json
+++ b/MST_Extra_BN/recipes/recipe_other.json
@@ -595,5 +595,226 @@
     "reversible": true,
     "autolearn": true,
     "components": [ [ [ "cordage_6_leather", 6 ] ] ]
-  }
+  },
+  	{
+		"type": "recipe",
+		"result": "jar_clay_yeast",
+		"category": "CC_FOOD",
+		"subcategory": "CSC_FOOD_OTHER",
+		"skill_used": "cooking",
+		"difficulty": 2,
+		"time": "30 m",
+		"autolearn": true,
+		"tools": [
+			[
+				["surface_heat", 7, "LIST"]
+			]
+		],
+		"components": [
+			[
+				["water", 1],
+				["water_clean", 1]
+			],
+			[
+				["jar_clay", 1]
+			],
+			[
+				["yeast", 1]
+			],
+			[
+				["beverage_sweetener", 1, "LIST"]
+			]
+		]
+	},
+	{
+		"type": "recipe",
+		"result": "jar_clay_wild_yeast",
+		"category": "CC_FOOD",
+		"subcategory": "CSC_FOOD_OTHER",
+		"skill_used": "cooking",
+		"difficulty": 4,
+		"skills_required": ["survival", 4],
+		"time": "20 m",
+		"book_learn": [
+			["brewing_cookbook", 1],
+			["textbook_survival", 1]
+		],
+		"autolearn": true,
+		"qualities": [{
+			"id": "BOIL",
+			"level": 2
+		}],
+		"tools": [
+			[
+				["surface_heat", 10, "LIST"]
+			]
+		],
+		"components": [
+			[
+				["water", 1],
+				["water_clean", 1]
+			],
+			[
+				["jar_clay", 1]
+			],
+			[
+				["sweet_fruit", 1, "LIST"]
+			],
+			[
+				["beverage_sweetener", 1, "LIST"]
+			]
+		]
+	},
+	{
+		"type": "recipe",
+		"result": "jar_clay_eggs_ferment",
+		"category": "CC_FOOD",
+		"subcategory": "CSC_FOOD_OTHER",
+		"skill_used": "cooking",
+		"difficulty": 5,
+		"time": "30 m",
+		"batch_time_factors": [80, 5],
+		"book_learn": [
+			["fermenting_book", 4]
+		],
+		"qualities": [{
+			"id": "COOK",
+			"level": 3
+		}],
+		"tools": [
+			[
+				["surface_heat", 20, "LIST"]
+			]
+		],
+		"components": [
+			[
+				["water", 1],
+				["water_clean", 1]
+			],
+			[
+				["vinegar", 1]
+			],
+			[
+				["saline", 1],
+				["salt", 2]
+			],
+			[
+				["jar_clay", 1]
+			],
+			[
+				["boiled_egg", 6]
+			]
+		]
+	},
+	{
+		"type": "recipe",
+		"result": "jar_clay_sauerkraut_ferment",
+		"category": "CC_FOOD",
+		"subcategory": "CSC_FOOD_VEGGI",
+		"skill_used": "cooking",
+		"difficulty": 5,
+		"time": "30 m",
+		"batch_time_factors": [80, 5],
+		"book_learn": [
+			["fermenting_book", 2],
+			["cookbook_foodfashions", 4]
+		],
+		"qualities": [{
+			"id": "CUT",
+			"level": 1
+		}, {
+			"id": "COOK",
+			"level": 3
+		}],
+		"tools": [
+			[
+				["surface_heat", 20, "LIST"]
+			]
+		],
+		"components": [
+			[
+				["water", 1],
+				["water_clean", 1]
+			],
+			[
+				["salt_water", 1],
+				["saline", 2],
+				["salt", 2]
+			],
+			[
+				["jar_clay", 1]
+			],
+			[
+				["veggy", 1],
+				["lettuce", 1],
+				["veggy_wild", 1],
+				["cabbage", 1]
+			]
+		]
+	},
+	{
+		"type": "recipe",
+		"result": "jar_clay_veggy_pickled",
+		"id_suffix": "jarred",
+		"container": "jar_clay_sealed",
+		"category": "CC_FOOD",
+		"subcategory": "CSC_FOOD_VEGGI",
+		"skill_used": "cooking",
+		"difficulty": 5,
+		"time": "30 m",
+		"result_mult": 2,
+		"book_learn": [
+			["manual_canning", 4]
+		],
+		"batch_time_factors": [80, 5],
+		"qualities": [{
+			"id": "CUT",
+			"level": 1
+		}, {
+			"id": "COOK",
+			"level": 3
+		}],
+		"tools": [
+			[
+				["surface_heat", 20, "LIST"]
+			]
+		],
+		"//": "Canned tomatoes aren't an option as they've already been preserved.",
+		"components": [
+			[
+				["water", 1],
+				["water_clean", 1],
+				["salt_water", 1],
+				["saline", 5]
+			],
+			[
+				["jar_clay", 1]
+			],
+			[
+				["veggy", 2],
+				["veggy_wild", 2],
+				["mushroom", 2],
+				["tomato", 2],
+				["irradiated_tomato", 2],
+				["broccoli", 2],
+				["irradiated_broccoli", 2],
+				["zucchini", 2],
+				["irradiated_zucchini", 2],
+				["cucumber", 2],
+				["irradiated_cucumber", 2],
+				["potato", 2],
+				["irradiated_potato", 2],
+				["corn", 2],
+				["irradiated_corn", 2],
+				["onion", 2],
+				["irradiated_onion", 2],
+				["garlic_clove", 12],
+				["irradiated_carrot", 4],
+				["carrot", 4]
+			],
+			[
+				["vinegar", 1]
+			]
+		]
+	}
 ]


### PR DESCRIPTION
Added clay jar recipes for most foodstuff:

- Sealed wild yeast culture.
- Sealed yeast culture.
- Pickled eggs.
- Sauerkraut
- Pickle veggies
- Juvenile sourdough starter.
- Freshly fed sourdough starter.

Tested and it seemed to work as intended. 

To-Do: Add clay jar support for 3L clay jars.
