### PR TITLE
Pending BN update: use of COMPACT flag for accessories

### DIFF
--- a/MST_Extra_BN/items/armor.json
+++ b/MST_Extra_BN/items/armor.json
@@ -40,7 +40,7 @@
       "draw_cost": 3,
       "flags": [ "SHEATH_KNIFE" ]
     },
-    "flags": [ "WAIST", "OVERSIZE", "WATER_FRIENDLY" ]
+    "flags": [ "WAIST", "COMPACT", "OVERSIZE", "WATER_FRIENDLY" ]
   },
   {
     "id": "armwrap_leather",

--- a/MST_Extra_BN/items/containers.json
+++ b/MST_Extra_BN/items/containers.json
@@ -17,7 +17,7 @@
     "seals": true,
     "watertight": true,
     "armor_data": { "covers": [ "leg_either" ], "coverage": 5, "encumbrance": 5, "material_thickness": 1 },
-    "flags": [ "WAIST", "OVERSIZE", "WATER_FRIENDLY" ]
+    "flags": [ "WAIST", "COMPACT", "OVERSIZE", "WATER_FRIENDLY" ]
   },
   {
     "id": "jar_clay",

--- a/MST_Extra_BN/items/tool_armor.json
+++ b/MST_Extra_BN/items/tool_armor.json
@@ -33,7 +33,7 @@
     "volume": "2500 ml",
     "encumbrance": 10,
     "bashing": 4,
-    "flags": [ "WAIST" ],
+    "flags": [ "WAIST", "COMPACT" ],
     "coverage": 10,
     "material_thickness": 2
   },


### PR DESCRIPTION
Set aside as a draft for if https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3792 is merged. Just adds the `COMPACT` flag to birchbark sheath, birchbark canteen, and side drum.