### PR TITLE
Pending BN Update: Take Cover!

### DIFF
--- a/MST_Extra/furniture_and_terrain/furniture.json
+++ b/MST_Extra/furniture_and_terrain/furniture.json
@@ -77,6 +77,7 @@
     "looks_like": "t_wall_log_half",
     "description": "A waist-high barricade made of stout saplings, held in place by poles hammered into the ground.  Primarily used to keep the wind out, but also works to fence in  a campsite.",
     "move_cost_mod": -1,
+    "coverage": 60,
     "required_str": -1,
     "flags": [
       "CLIMB_SIMPLE",

--- a/MST_Extra/furniture_and_terrain/terrain.json
+++ b/MST_Extra/furniture_and_terrain/terrain.json
@@ -7,6 +7,7 @@
     "symbol": "^",
     "color": "light_gray",
     "move_cost": 0,
+    "coverage": 60,
     "transforms_into": "t_hive_growing",
     "deconstruct": { "ter_set": "t_dirt", "items": [ { "item": "beehive_empty", "count": 1 } ] },
     "flags": [ "FLAMMABLE_ASH", "TRANSPARENT", "PERMEABLE", "NOITEM", "EASY_DECONSTRUCT", "HARVESTED" ],
@@ -20,7 +21,8 @@
         { "item": "2x4", "count": [ 1, 4 ] },
         { "item": "nail", "charges": [ 4, 8 ] },
         { "item": "splinter", "count": [ 2, 6 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 38, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -31,6 +33,7 @@
     "symbol": "^",
     "color": "brown",
     "move_cost": 0,
+    "coverage": 60,
     "transforms_into": "t_hive_ready",
     "deconstruct": { "ter_set": "t_dirt", "items": [ { "item": "beehive_empty", "count": 1 }, { "item": "wax", "count": [ 1, 6 ] } ] },
     "flags": [ "FLAMMABLE_ASH", "TRANSPARENT", "PERMEABLE", "NOITEM", "EASY_DECONSTRUCT", "HARVESTED" ],
@@ -56,6 +59,7 @@
     "symbol": "^",
     "color": "yellow",
     "move_cost": 0,
+    "coverage": 60,
     "transforms_into": "t_hive_recovering",
     "examine_action": "harvest_ter",
     "harvest_by_season": [ { "seasons": [ "spring", "summer", "autumn", "winter" ], "id": "hive_ready_harv" } ],
@@ -87,6 +91,7 @@
     "symbol": "^",
     "color": "brown",
     "move_cost": 0,
+    "coverage": 60,
     "transforms_into": "t_hive_regrowing",
     "deconstruct": {
       "ter_set": "t_dirt",
@@ -115,6 +120,7 @@
     "symbol": "^",
     "color": "brown",
     "move_cost": 0,
+    "coverage": 60,
     "transforms_into": "t_hive_ready",
     "deconstruct": {
       "ter_set": "t_dirt",

--- a/MST_Extra_BN/furniture_and_terrain/furniture.json
+++ b/MST_Extra_BN/furniture_and_terrain/furniture.json
@@ -77,6 +77,7 @@
     "looks_like": "t_wall_log_half",
     "description": "A waist-high barricade made of stout saplings, held in place by poles hammered into the ground.  Primarily used to keep the wind out, but also works to fence in  a campsite.",
     "move_cost_mod": -1,
+    "coverage": 60,
     "required_str": -1,
     "flags": [
       "CLIMB_SIMPLE",
@@ -97,7 +98,8 @@
       "str_max": 40,
       "sound": "smash!",
       "sound_fail": "whump.",
-      "items": [ { "item": "stick", "count": [ 2, 6 ] }, { "item": "splinter", "count": [ 2, 6 ] } ]
+      "items": [ { "item": "stick", "count": [ 2, 6 ] }, { "item": "splinter", "count": [ 2, 6 ] } ],
+      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -146,7 +148,8 @@
       "str_max": 38,
       "sound": "smash!",
       "sound_fail": "whump.",
-      "items": [ { "item": "2x4", "count": [ 2, 6 ] }, { "item": "splinter", "count": 12 } ]
+      "items": [ { "item": "2x4", "count": [ 2, 6 ] }, { "item": "splinter", "count": 12 } ],
+      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 38, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -169,6 +172,7 @@
       "sound": "smash!",
       "sound_fail": "whump.",
       "items": [ { "item": "2x4", "count": [ 2, 5 ] }, { "item": "splinter", "count": 3 } ]
+      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 38, "block_unaimed_chance": "50%" }
     },
     "examine_action": "workbench",
     "workbench": { "multiplier": 1.1, "mass": 200000, "volume": "75L" }
@@ -192,7 +196,8 @@
       "str_max": 50,
       "sound": "smash!",
       "sound_fail": "whump.",
-      "items": [ { "item": "2x4", "count": [ 2, 4 ] }, { "item": "splinter", "count": 3 } ]
+      "items": [ { "item": "2x4", "count": [ 2, 4 ] }, { "item": "splinter", "count": 3 } ],
+      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 50, "block_unaimed_chance": "50%" }
     },
     "examine_action": "workbench",
     "workbench": { "multiplier": 1.1, "mass": 200000, "volume": "75L" }
@@ -219,7 +224,8 @@
       "str_max": 18,
       "sound": "smash!",
       "sound_fail": "whump.",
-      "items": [ { "item": "2x4", "count": [ 0, 2 ] }, { "item": "splinter", "count": 1 } ]
+      "items": [ { "item": "2x4", "count": [ 0, 2 ] }, { "item": "splinter", "count": 1 } ],
+      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 18, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -244,7 +250,8 @@
       "str_max": 38,
       "sound": "smash!",
       "sound_fail": "whump.",
-      "items": [ { "item": "2x4", "count": [ 0, 2 ] }, { "item": "splinter", "count": 1 } ]
+      "items": [ { "item": "2x4", "count": [ 0, 2 ] }, { "item": "splinter", "count": 1 } ],
+      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 38, "block_unaimed_chance": "25%" }
     }
   },
   {

--- a/MST_Extra_BN/furniture_and_terrain/terrain.json
+++ b/MST_Extra_BN/furniture_and_terrain/terrain.json
@@ -7,6 +7,7 @@
     "symbol": "^",
     "color": "light_gray",
     "move_cost": 0,
+    "coverage": 60,
     "transforms_into": "t_hive_growing",
     "deconstruct": { "ter_set": "t_dirt", "items": [ { "item": "beehive_empty", "count": 1 } ] },
     "flags": [ "FLAMMABLE_ASH", "TRANSPARENT", "PERMEABLE", "NOITEM", "EASY_DECONSTRUCT", "HARVESTED" ],
@@ -20,7 +21,8 @@
         { "item": "2x4", "count": [ 1, 4 ] },
         { "item": "nail", "charges": [ 4, 8 ] },
         { "item": "splinter", "count": [ 2, 6 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -31,6 +33,7 @@
     "symbol": "^",
     "color": "brown",
     "move_cost": 0,
+    "coverage": 60,
     "transforms_into": "t_hive_ready",
     "deconstruct": { "ter_set": "t_dirt", "items": [ { "item": "beehive_empty", "count": 1 }, { "item": "wax", "count": [ 1, 6 ] } ] },
     "flags": [ "FLAMMABLE_ASH", "TRANSPARENT", "PERMEABLE", "NOITEM", "EASY_DECONSTRUCT", "HARVESTED" ],
@@ -45,7 +48,8 @@
         { "item": "2x4", "count": [ 1, 4 ] },
         { "item": "nail", "charges": [ 4, 8 ] },
         { "item": "splinter", "count": [ 2, 6 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -56,6 +60,7 @@
     "symbol": "^",
     "color": "yellow",
     "move_cost": 0,
+    "coverage": 60,
     "transforms_into": "t_hive_recovering",
     "examine_action": "harvest_ter",
     "harvest_by_season": [
@@ -81,7 +86,8 @@
         { "item": "2x4", "count": [ 1, 4 ] },
         { "item": "nail", "charges": [ 4, 8 ] },
         { "item": "splinter", "count": [ 2, 6 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -92,6 +98,7 @@
     "symbol": "^",
     "color": "brown",
     "move_cost": 0,
+    "coverage": 60,
     "transforms_into": "t_hive_regrowing",
     "deconstruct": {
       "ter_set": "t_dirt",
@@ -109,7 +116,8 @@
         { "item": "2x4", "count": [ 1, 4 ] },
         { "item": "nail", "charges": [ 4, 8 ] },
         { "item": "splinter", "count": [ 2, 6 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -120,6 +128,7 @@
     "symbol": "^",
     "color": "brown",
     "move_cost": 0,
+    "coverage": 60,
     "transforms_into": "t_hive_ready",
     "deconstruct": {
       "ter_set": "t_dirt",
@@ -138,7 +147,8 @@
         { "item": "2x4", "count": [ 1, 4 ] },
         { "item": "nail", "charges": [ 4, 8 ] },
         { "item": "splinter", "count": [ 2, 6 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
     }
   },
   {


### PR DESCRIPTION
Simple lil self-PR set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/4129 is merged. Applies the newly available ballistic resistance properties to relevant furniture, and also adds coverage and resistance to beehives and such.