### PR TITLE
Pending BN Update: vehicle repairs require materials

### DIFF
--- a/MST_Extra/vehicles/vehicleparts.json
+++ b/MST_Extra/vehicles/vehicleparts.json
@@ -217,7 +217,7 @@
     "requirements": {
       "install": { "skills": [ [ "survival", 1 ] ], "time": "40 m", "using": [ [ "cordage_short", 4 ] ] },
       "removal": { "skills": [ [ "survival", 1 ] ], "time": "20 m" },
-      "repair": { "skills": [ [ "survival", 2 ] ], "time": "40 m", "using": [ [ "cordage_short", 1 ] ] }
+      "repair": { "skills": [ [ "survival", 2 ] ], "time": "40 m", "using": [ [ "cordage_short", 2 ] ] }
     },
     "flags": [ "BED", "BOARDABLE", "CARGO", "MOUNTABLE" ],
     "breaks_into": [ { "item": "straw_pile", "count": [ 7, 8 ] } ],

--- a/MST_Extra_BN/vehicles/vehicleparts.json
+++ b/MST_Extra_BN/vehicles/vehicleparts.json
@@ -16,7 +16,7 @@
     "requirements": {
       "install": { "skills": [ [ "survival", 0 ] ], "time": "15 m", "using": [ [ "vehicle_sled", 1 ] ] },
       "removal": { "skills": [ [ "survival", 0 ] ], "time": "10 m" },
-      "repair": { "skills": [ [ "survival", 1 ] ], "time": "15 m", "using": [ [ "vehicle_sled", 1 ] ] }
+      "repair": { "skills": [ [ "survival", 1 ] ], "time": "15 m", "using": [ [ "vehicle_sled", 1 ], [ "vehicle_repair_small_wood", 4 ] ] }
     },
     "damage_reduction": { "all": 6 }
   },
@@ -40,7 +40,7 @@
     "requirements": {
       "install": { "skills": [ [ "survival", 0 ] ], "time": "15 m", "using": [ [ "vehicle_sled", 1 ] ] },
       "removal": { "skills": [ [ "survival", 0 ] ], "time": "10 m" },
-      "repair": { "skills": [ [ "survival", 1 ] ], "time": "15 m", "using": [ [ "vehicle_sled", 1 ] ] }
+      "repair": { "skills": [ [ "survival", 1 ] ], "time": "15 m", "using": [ [ "vehicle_sled", 1 ], [ "vehicle_repair_small_wood", 2 ] ] }
     },
     "damage_reduction": { "all": 8 }
   },
@@ -64,7 +64,7 @@
     "requirements": {
       "install": { "skills": [ [ "survival", 1 ] ], "time": "15 m", "using": [ [ "vehicle_sled", 1 ] ] },
       "removal": { "skills": [ [ "survival", 1 ] ], "time": "10 m" },
-      "repair": { "skills": [ [ "survival", 2 ] ], "time": "15 m", "using": [ [ "vehicle_sled", 1 ] ] }
+      "repair": { "skills": [ [ "survival", 2 ] ], "time": "15 m", "using": [ [ "vehicle_sled", 1 ], [ "vehicle_repair_small_wood", 4 ] ] }
     },
     "damage_reduction": { "all": 6 }
   },
@@ -85,7 +85,7 @@
     "requirements": {
       "install": { "skills": [ [ "survival", 2 ] ], "time": "20 m", "using": [ [ "vehicle_birchbark_boat", 1 ] ] },
       "removal": { "skills": [ [ "survival", 2 ] ], "time": "10 m" },
-      "repair": { "skills": [ [ "survival", 3 ] ], "time": "20 m", "using": [ [ "adhesive", 1 ] ] }
+      "repair": { "skills": [ [ "survival", 3 ] ], "time": "20 m", "using": [ [ "adhesive", 1 ], [ "vehicle_repair_small_wood", 4 ] ] }
     },
     "flags": [ "FLOATS" ],
     "breaks_into": [ { "item": "birchbark", "count": [ 0, 6 ] } ],
@@ -107,7 +107,7 @@
     "requirements": {
       "install": { "skills": [ [ "survival", 1 ] ], "time": "20 m", "using": [ [ "vehicle_sled", 1 ] ] },
       "removal": { "skills": [ [ "survival", 1 ] ], "time": "10 m" },
-      "repair": { "skills": [ [ "survival", 2 ] ], "time": "20 m", "using": [ [ "adhesive", 1 ] ] }
+      "repair": { "skills": [ [ "survival", 2 ] ], "time": "20 m", "using": [ [ "adhesive", 1 ], [ "vehicle_repair_small_wood", 4 ] ] }
     },
     "flags": [ "AISLE", "BOARDABLE" ],
     "breaks_into": [ { "item": "birchbark", "count": [ 0, 6 ] } ],
@@ -128,7 +128,7 @@
     "requirements": {
       "install": { "skills": [ [ "survival", 1 ] ], "time": "20 m", "using": [ [ "vehicle_sled", 1 ] ] },
       "removal": { "skills": [ [ "survival", 1 ] ], "time": "10 m" },
-      "repair": { "skills": [ [ "survival", 2 ] ], "time": "20 m", "using": [ [ "adhesive", 1 ] ] }
+      "repair": { "skills": [ [ "survival", 2 ] ], "time": "20 m", "using": [ [ "adhesive", 1 ], [ "vehicle_repair_small_wood", 4 ] ] }
     },
     "flags": [ "ROOF" ],
     "breaks_into": [ { "item": "birchbark", "count": [ 0, 6 ] } ],
@@ -152,7 +152,7 @@
     "requirements": {
       "install": { "skills": [ [ "survival", 1 ] ], "time": "30 m", "using": [ [ "vehicle_log_frame", 1 ] ] },
       "removal": { "skills": [ [ "survival", 1 ] ], "time": "15 m" },
-      "repair": { "skills": [ [ "survival", 2 ] ], "time": "30 m", "using": [ [ "adhesive", 1 ] ] }
+      "repair": { "skills": [ [ "survival", 2 ] ], "time": "30 m", "using": [ [ "adhesive", 1 ], [ "wood_structural_small", 1 ] ] }
     },
     "damage_reduction": { "all": 52 }
   },
@@ -173,7 +173,7 @@
     "requirements": {
       "install": { "skills": [ [ "survival", 1 ] ], "time": "30 m", "using": [ [ "vehicle_log_frame", 1 ] ] },
       "removal": { "skills": [ [ "survival", 1 ] ], "time": "15 m" },
-      "repair": { "skills": [ [ "survival", 3 ] ], "time": "30 m", "using": [ [ "adhesive", 1 ] ] }
+      "repair": { "skills": [ [ "survival", 3 ] ], "time": "30 m", "using": [ [ "adhesive", 1 ], [ "wood_structural_small", 1 ] ] }
     },
     "flags": [ "OBSTACLE", "OPENABLE", "BOARDABLE", "OPAQUE", "AISLE" ],
     "breaks_into": [ { "item": "splinter", "count": [ 20, 30 ] } ],
@@ -193,7 +193,7 @@
     "requirements": {
       "install": { "skills": [ [ "survival", 1 ] ], "time": "30 m", "using": [ [ "vehicle_log_frame", 1 ] ] },
       "removal": { "skills": [ [ "survival", 1 ] ], "time": "15 m" },
-      "repair": { "skills": [ [ "survival", 3 ] ], "time": "30 m", "using": [ [ "adhesive", 1 ] ] }
+      "repair": { "skills": [ [ "survival", 3 ] ], "time": "30 m", "using": [ [ "adhesive", 1 ], [ "wood_structural_small", 1 ] ] }
     },
     "flags": [ "OPAQUE", "OBSTACLE", "FULL_BOARD", "NO_ROOF_NEEDED" ],
     "damage_reduction": { "all": 32, "cut": 16, "stab": 16 }
@@ -260,7 +260,7 @@
     "requirements": {
       "install": { "skills": [ [ "survival", 1 ] ], "time": "40 m", "using": [ [ "cordage_short", 4 ] ] },
       "removal": { "skills": [ [ "survival", 1 ] ], "time": "20 m" },
-      "repair": { "skills": [ [ "survival", 2 ] ], "time": "40 m", "using": [ [ "cordage_short", 1 ] ] }
+      "repair": { "skills": [ [ "survival", 2 ] ], "time": "40 m", "using": [ [ "cordage_short", 2 ] ] }
     },
     "flags": [ "BED", "BOARDABLE", "CARGO", "MOUNTABLE" ],
     "breaks_into": [ { "item": "straw_pile", "count": [ 7, 8 ] } ],


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/4293 is merged, adds use of `vehicle_repair_small_wood`and/or `wood_structural_small` to relevant vehiclepart repairs, also bumped cordage use up for straw bed vehicleparts. I could add a quality for "straw or pine boughs" but it'd be used for literally just one vehiclepart so eck.