### PR TITLE
Pending BN Update: `ALLOWS_REMOTE_USE` works on more stuff

### DIFF
--- a/MST_Extra_BN/items/tool_armor.json
+++ b/MST_Extra_BN/items/tool_armor.json
@@ -84,7 +84,7 @@
     "warmth": 30,
     "material_thickness": 1,
     "environmental_protection": 1,
-    "flags": [ "OVERSIZE", "OUTER", "ALLOWS_NATURAL_ATTACKS" ],
+    "flags": [ "OVERSIZE", "OUTER", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_REMOTE_USE" ],
     "use_action": {
       "type": "place_trap",
       "allow_under_player": true,

--- a/MST_Extra_BN/items/tools.json
+++ b/MST_Extra_BN/items/tools.json
@@ -85,7 +85,8 @@
       "vehicle_name": "makeshift_sled_vehicle",
       "unfold_msg": "You unfold and deploy the makeshift sled.",
       "moves": 200
-    }
+    },
+    "flags": [ "ALLOWS_REMOTE_USE" ]
   },
   {
     "id": "log_canoe_item",
@@ -105,7 +106,8 @@
       "vehicle_name": "log_canoe_vehicle",
       "unfold_msg": "You deploy the log canoe.",
       "moves": 100
-    }
+    },
+    "flags": [ "ALLOWS_REMOTE_USE" ]
   },
   {
     "id": "mound_distillation",
@@ -131,7 +133,6 @@
     "description": "Some sticks and string with a leather tarp, to set up an improvised raincatcher.",
     "weight": "4736 g",
     "material": [ "wood", "leather" ],
-    "extend": { "flags": [ "ALLOWS_REMOTE_USE" ] },
     "use_action": {
       "type": "place_trap",
       "allow_under_player": true,

--- a/MST_Extra_BN/items/tools.json
+++ b/MST_Extra_BN/items/tools.json
@@ -131,6 +131,7 @@
     "description": "Some sticks and string with a leather tarp, to set up an improvised raincatcher.",
     "weight": "4736 g",
     "material": [ "wood", "leather" ],
+    "extend": { "flags": [ "ALLOWS_REMOTE_USE" ] },
     "use_action": {
       "type": "place_trap",
       "allow_under_player": true,
@@ -254,7 +255,7 @@
     "symbol": ",",
     "color": "brown",
     "use_action": [ { "type": "deploy_furn", "furn_type": "f_hobo_stove_clay_placed" } ],
-    "flags": [ "SHATTERS" ]
+    "flags": [ "SHATTERS", "ALLOWS_REMOTE_USE" ]
   },
   {
     "id": "misc_repairkit_makeshift",


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/5186 is merged, adds `ALLOWS_REMOTE_USE` to relevant `deploy_furn` and `place_trap` items. Applying the flag to traps isn't yet implemented in vanilla BN, gonna do that in a followup PR, but testing with straw bedding in this mod confirms it works fully as expected.