### PR TITLE
Pending BN Update: Serpent mutation category

### DIFF
--- a/MST_Extra_BN/items/armor.json
+++ b/MST_Extra_BN/items/armor.json
@@ -40,7 +40,7 @@
       "draw_cost": 3,
       "flags": [ "SHEATH_KNIFE" ]
     },
-    "flags": [ "WAIST", "COMPACT", "OVERSIZE", "WATER_FRIENDLY" ]
+    "flags": [ "WAIST", "COMPACT", "OVERSIZE", "WATER_FRIENDLY", "ALLOWS_TAIL_SNAKE" ]
   },
   {
     "id": "armwrap_leather",
@@ -134,7 +134,7 @@
     "encumbrance": 10,
     "warmth": 10,
     "material_thickness": 1,
-    "flags": [ "OVERSIZE", "OUTER", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "OVERSIZE", "OUTER", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_TAIL_SNAKE" ]
   },
   {
     "id": "cloak_makeshift_blanket",

--- a/MST_Extra_BN/items/containers.json
+++ b/MST_Extra_BN/items/containers.json
@@ -17,7 +17,7 @@
     "seals": true,
     "watertight": true,
     "armor_data": { "covers": [ "leg_either" ], "coverage": 5, "encumbrance": 5, "material_thickness": 1 },
-    "flags": [ "WAIST", "COMPACT", "OVERSIZE", "WATER_FRIENDLY" ]
+    "flags": [ "WAIST", "COMPACT", "OVERSIZE", "WATER_FRIENDLY", "ALLOWS_TAIL_SNAKE" ]
   },
   {
     "id": "jar_clay",

--- a/MST_Extra_BN/items/tool_armor.json
+++ b/MST_Extra_BN/items/tool_armor.json
@@ -84,7 +84,7 @@
     "warmth": 30,
     "material_thickness": 1,
     "environmental_protection": 1,
-    "flags": [ "OVERSIZE", "OUTER", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_REMOTE_USE", "DESTROY_ON_DECHARGE" ],
+    "flags": [ "OVERSIZE", "OUTER", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_REMOTE_USE", "DESTROY_ON_DECHARGE", "ALLOWS_TAIL_SNAKE" ],
     "use_action": {
       "type": "place_trap",
       "allow_under_player": true,


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/7093 is merged, adds `ALLOWS_TAIL_SNAKE` to birchbark sheath, blanket cloak, and birchbark canteen.