### PR TITLE
Pending BN feature: more use of `ALLOWS_X` flags for mutations

### DIFF
--- a/MST_Extra_BN/items/armor.json
+++ b/MST_Extra_BN/items/armor.json
@@ -16,7 +16,7 @@
     "encumbrance": 12,
     "storage": "15 L",
     "material_thickness": 2,
-    "flags": [ "BELTED", "WATER_FRIENDLY" ]
+    "flags": [ "BELTED", "WATER_FRIENDLY", "ALLOWS_WINGS" ]
   },
   {
     "id": "sheath_birchbark",
@@ -243,4 +243,3 @@
     "use_action": { "type": "bandolier", "capacity": 10, "ammo": [ "atlatl" ], "draw_cost": 30 }
   }
 ]
-

--- a/MST_Extra_BN/items/containers.json
+++ b/MST_Extra_BN/items/containers.json
@@ -17,7 +17,7 @@
     "seals": true,
     "watertight": true,
     "armor_data": { "covers": [ "leg_either" ], "coverage": 5, "encumbrance": 5, "material_thickness": 1 },
-    "flags": [ "WAIST", "COMPACT", "OVERSIZE", "WATER_FRIENDLY", "ALLOWS_TAIL_SNAKE" ]
+    "flags": [ "WAIST", "COMPACT", "OVERSIZE", "WATER_FRIENDLY", "ALLOWS_TAIL_SNAKE", "ALLOWS_TAIL" ]
   },
   {
     "id": "jar_clay",

--- a/MST_Extra_BN/items/tool_armor.json
+++ b/MST_Extra_BN/items/tool_armor.json
@@ -33,7 +33,7 @@
     "volume": "2500 ml",
     "encumbrance": 10,
     "bashing": 4,
-    "flags": [ "WAIST", "COMPACT" ],
+    "flags": [ "WAIST", "COMPACT", "ALLOWS_WINGS" ],
     "coverage": 10,
     "material_thickness": 2
   },
@@ -62,7 +62,7 @@
     "max_charges": 100,
     "ammo": [ "gasfilter_m" ],
     "use_action": "GASMASK",
-    "flags": [ "OUTER", "HELMET_COMPAT" ]
+    "flags": [ "OUTER", "HELMET_COMPAT", "ALLOWS_MUZZLE" ]
   },
   {
     "id": "straw_bed_rollmat",
@@ -84,7 +84,15 @@
     "warmth": 30,
     "material_thickness": 1,
     "environmental_protection": 1,
-    "flags": [ "OVERSIZE", "OUTER", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_REMOTE_USE", "DESTROY_ON_DECHARGE", "ALLOWS_TAIL_SNAKE" ],
+    "flags": [
+      "OVERSIZE",
+      "OUTER",
+      "ALLOWS_NATURAL_ATTACKS",
+      "ALLOWS_REMOTE_USE",
+      "DESTROY_ON_DECHARGE",
+      "ALLOWS_TAIL_SNAKE",
+      "ALLOWS_HOOVES"
+    ],
     "use_action": {
       "type": "place_trap",
       "allow_under_player": true,

--- a/MST_Extra_BN/modinfo.json
+++ b/MST_Extra_BN/modinfo.json
@@ -5,7 +5,7 @@
     "name": "MST Extra",
     "authors": [ "Chaosvolt" ],
     "description": "The sequeal to CDDA's old More Survival Tools mod, adding additional useful innawoods content.",
-    "version": "BN version, update 8/4/2025",
+    "version": "BN version, update 9/11/2025",
     "category": "items",
     "dependencies": [ "bn" ]
   }


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/7205 is merged, adds relevant use new `ALLOWS_X` flags on items.