### PR TITLE
Pending BN Update: removal of `INDOORS` terrain flag

### DIFF
--- a/MST_Extra_BN/furniture_and_terrain/furniture.json
+++ b/MST_Extra_BN/furniture_and_terrain/furniture.json
@@ -136,7 +136,7 @@
     "coverage": 15,
     "required_str": -1,
     "//": "INDOORS and BLOCK_WIND are used to ensure it doesn't go out.  Doesn't let you move onto it to prevent exploiting that.",
-    "flags": [ "PLACE_ITEM", "TRANSPARENT", "FIRE_CONTAINER", "EASY_DECONSTRUCT", "INDOORS", "BLOCK_WIND" ],
+    "flags": [ "PLACE_ITEM", "TRANSPARENT", "FIRE_CONTAINER", "EASY_DECONSTRUCT", "BLOCK_WIND" ],
     "deployed_item": "hobo_stove_clay",
     "examine_action": "fireplace",
     "max_volume": "55 L",

--- a/MST_Extra_BN/obsolete.json
+++ b/MST_Extra_BN/obsolete.json
@@ -222,7 +222,7 @@
     "coverage": 15,
     "required_str": 1,
     "//": "INDOORS and BLOCK_WIND are used to ensure it doesn't go out.  Doesn't let you move onto it to prevent exploiting that.",
-    "flags": [ "PLACE_ITEM", "TRANSPARENT", "FIRE_CONTAINER", "EASY_DECONSTRUCT", "INDOORS", "BLOCK_WIND" ],
+    "flags": [ "PLACE_ITEM", "TRANSPARENT", "FIRE_CONTAINER", "EASY_DECONSTRUCT", "BLOCK_WIND" ],
     "deployed_item": "hobo_stove",
     "examine_action": "fireplace",
     "max_volume": "1 L",
@@ -340,7 +340,7 @@
       "ter_set": "t_dirt",
       "items": [ { "item": "pointy_stick", "count": 4 }, { "item": "withered", "count": 8 }, { "item": "leather_tarp", "count": 1 } ]
     },
-    "flags": [ "TRANSPARENT", "FLAMMABLE", "THIN_OBSTACLE", "INDOORS", "MOUNTABLE", "EASY_DECONSTRUCT" ]
+    "flags": [ "TRANSPARENT", "FLAMMABLE", "THIN_OBSTACLE", "MOUNTABLE", "EASY_DECONSTRUCT" ]
   },
   {
     "type": "furniture",


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbn/Cataclysm-BN/pull/8542 is merged, removing use of the now unused `INDOORS` flag.